### PR TITLE
Made sure the parent resolution is of type int internally

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -107,6 +107,7 @@ def assemble_kwargs(
 
     return kwargs
 
+
 def zero_padding(dggs: str) -> int:
     max_res_lookup = {
         "h3": const.MAX_H3,
@@ -120,6 +121,7 @@ def zero_padding(dggs: str) -> int:
         raise ValueError(f"Unknown DGGS type: {dggs}")
     return len(str(max_res))
 
+
 def get_parent_res(dggs: str, parent_res: Union[None, int], resolution: int) -> int:
     """
     Uses a parent resolution,
@@ -128,20 +130,17 @@ def get_parent_res(dggs: str, parent_res: Union[None, int], resolution: int) -> 
 
     Used for intermediate re-partioning.
     """
-    default_dggs_parent_res = {
-        "h3": max(const.MIN_H3, (resolution - const.DEFAULT_PARENT_OFFSET)),
-        "rhp": max(const.MIN_RHP, (resolution - const.DEFAULT_PARENT_OFFSET)),
-        "geohash": max(const.MIN_GEOHASH, (resolution - const.DEFAULT_PARENT_OFFSET)),
-        "maidenhead": const.MIN_MAIDENHEAD,
-        "s2": max(const.MIN_S2, (resolution - const.DEFAULT_PARENT_OFFSET)),
-    }
-    if not dggs in default_dggs_parent_res:
+    if not dggs in const.DEFAULT_DGGS_PARENT_RES.keys():
         raise RuntimeError(
             "Unknown dggs {dggs}) -  must be one of [ {options} ]".format(
-                dggs=dggs, options=", ".join(default_dggs_parent_res.keys())
+                dggs=dggs, options=", ".join(const.DEFAULT_DGGS_PARENT_RES.keys())
             )
         )
-    return parent_res if parent_res is not None else default_dggs_parent_res[dggs]
+    return (
+        int(parent_res)
+        if parent_res is not None
+        else const.DEFAULT_DGGS_PARENT_RES[dggs]
+    )
 
 
 def address_boundary_issues(
@@ -166,8 +165,6 @@ def address_boundary_issues(
         of the original (i.e. window-based) partitioning. Using the nested structure of the DGGS is an useful property
         to address this problem.
     """
-    parent_res = get_parent_res(dggs, parent_res, resolution)
-
     LOGGER.debug(
         f"Reading Stage 1 output ({pq_input}) and setting index for parent-based partitioning"
     )

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -21,3 +21,13 @@ DEFAULTS = {
 }
 
 DEFAULT_PARENT_OFFSET = 6
+
+DEFAULT_DGGS_PARENT_RES = {
+    "h3": lambda resolution: max(MIN_H3, (resolution - DEFAULT_PARENT_OFFSET)),
+    "rhp": lambda resolution: max(MIN_RHP, (resolution - DEFAULT_PARENT_OFFSET)),
+    "geohash": lambda resolution: max(
+        MIN_GEOHASH, (resolution - DEFAULT_PARENT_OFFSET)
+    ),
+    "maidenhead": lambda resolution: MIN_MAIDENHEAD,
+    "s2": lambda resolution: max(MIN_S2, (resolution - DEFAULT_PARENT_OFFSET)),
+}

--- a/raster2dggs/geohash.py
+++ b/raster2dggs/geohash.py
@@ -17,7 +17,8 @@ import raster2dggs.common as common
 from raster2dggs import __version__
 
 
-PAD_WIDTH = common.zero_padding('geohash')
+PAD_WIDTH = common.zero_padding("geohash")
+
 
 def _geohashfunc(
     sdf: xr.DataArray,
@@ -46,7 +47,9 @@ def _geohashfunc(
     # Secondary (parent) Geohash index, used later for partitioning
     geohash_parent = [gh[:parent_precision] for gh in geohash]
     subset = subset.drop(columns=["x", "y"])
-    subset[f"geohash_{precision:0{PAD_WIDTH}d}"] = pd.Series(geohash, index=subset.index)
+    subset[f"geohash_{precision:0{PAD_WIDTH}d}"] = pd.Series(
+        geohash, index=subset.index
+    )
     subset[f"geohash_{parent_precision:0{PAD_WIDTH}d}"] = pd.Series(
         geohash_parent, index=subset.index
     )
@@ -71,7 +74,11 @@ def _geohash_parent_groupby(
     high resolution raster at a coarse Geohash precision.
     """
     if decimals > 0:
-        return df.groupby(f"geohash_{precision:0{PAD_WIDTH}d}").agg(aggfunc).round(decimals)
+        return (
+            df.groupby(f"geohash_{precision:0{PAD_WIDTH}d}")
+            .agg(aggfunc)
+            .round(decimals)
+        )
     else:
         return (
             df.groupby(f"geohash_{precision:0{PAD_WIDTH}d}")
@@ -201,7 +208,7 @@ def geohash(
         raster_input,
         output_directory,
         int(resolution),
-        int(parent_res),
+        parent_res,
         warp_args,
         **kwargs,
     )

--- a/raster2dggs/h3.py
+++ b/raster2dggs/h3.py
@@ -18,6 +18,7 @@ from raster2dggs import __version__
 
 PAD_WIDTH = common.zero_padding("h3")
 
+
 def _h3func(
     sdf: xr.DataArray,
     resolution: int,
@@ -194,7 +195,7 @@ def h3(
         raster_input,
         output_directory,
         int(resolution),
-        int(parent_res),
+        parent_res,
         warp_args,
         **kwargs,
     )

--- a/raster2dggs/maidenhead.py
+++ b/raster2dggs/maidenhead.py
@@ -201,7 +201,7 @@ def maidenhead(
         raster_input,
         output_directory,
         int(resolution),
-        int(parent_res),
+        parent_res,
         warp_args,
         **kwargs,
     )

--- a/raster2dggs/rHP.py
+++ b/raster2dggs/rHP.py
@@ -18,6 +18,7 @@ from raster2dggs import __version__
 
 PAD_WIDTH = common.zero_padding("h3")
 
+
 def _rhpfunc(
     sdf: xr.DataArray,
     resolution: int,
@@ -64,7 +65,9 @@ def _rhp_parent_groupby(
     high resolution raster at a coarser resolution.
     """
     if decimals > 0:
-        return df.groupby(f"rhp_{resolution:0{PAD_WIDTH}d}").agg(aggfunc).round(decimals)
+        return (
+            df.groupby(f"rhp_{resolution:0{PAD_WIDTH}d}").agg(aggfunc).round(decimals)
+        )
     else:
         return (
             df.groupby(f"rhp_{resolution:0{PAD_WIDTH}d}")
@@ -194,7 +197,7 @@ def rhp(
         raster_input,
         output_directory,
         int(resolution),
-        int(parent_res),
+        parent_res,
         warp_args,
         **kwargs,
     )

--- a/raster2dggs/s2.py
+++ b/raster2dggs/s2.py
@@ -18,6 +18,7 @@ from raster2dggs import __version__
 
 PAD_WIDTH = common.zero_padding("s2")
 
+
 def _s2func(
     sdf: xr.DataArray,
     resolution: int,
@@ -198,7 +199,7 @@ def s2(
         raster_input,
         output_directory,
         int(resolution),
-        int(parent_res),
+        parent_res,
         warp_args,
         **kwargs,
     )


### PR DESCRIPTION
What it says on the tin, really. I also moved the default parent resolution dictionary to `constants.py` so it looks like the version in vector2dggs. (This is just for consistency.)

Tested with a sample input raster for all five indexing systems to make sure they run to completion.