### PR TITLE
Implements hive partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,17 @@ Options:
 
 ## Visualising output
 
-Output is in the Apache Parquet format, a directory with one file per partition. Partitions are based on parent cell IDs, with the parent resolution determined as an offset from the target DGGS resolution.
+Output is in the Apache Parquet format, hive partitioned with the parent resolution as partition key. The example below is with `-pr 3` with the H3 DGGS.
+
+```bash
+tree /home/user/example.pq
+
+/home/user/example.pq
+├── h3_03=83bb09fffffffff
+│   └── part.0.parquet
+└── h3_03=83bb0dfffffffff
+    └── part.0.parquet
+```
 
 For a quick view of your output, you can read Apache Parquet with pandas, and then use h3-pandas and geopandas to convert this into a GeoPackage for visualisation in a desktop GIS, such as QGIS. The Apache Parquet output is indexed by the DGGS column, so it should be ready for association with other data prepared in the same DGGS.
 
@@ -198,18 +208,14 @@ from shapely.geometry import Polygon
 o = pd.read_parquet('./tests/data/output/7/sample_tif_s2')
 
 def s2id_to_polygon(s2_id_hex):
-    # Parse the S2CellId
     cell_id = s2sphere.CellId.from_token(s2_id_hex)
     cell = s2sphere.Cell(cell_id)
-
-    # Get the 4 vertices of the S2 cell
     vertices = []
     for i in range(4):
         vertex = cell.get_vertex(i)
         # Convert to lat/lon degrees
         lat_lng = s2sphere.LatLng.from_point(vertex)
         vertices.append((lat_lng.lng().degrees, lat_lng.lat().degrees))  # (lon, lat)
-    
     return Polygon(vertices)
 
 o['geometry'] = o.index.map(s2id_to_polygon)

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -32,7 +32,7 @@ from rasterio.warp import calculate_default_transform
 import raster2dggs.constants as const
 import raster2dggs.indexerfactory as idxfactory
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.interfaces import IRasterIndexer
 
 LOGGER = logging.getLogger(__name__)
 click_log.basic_config(LOGGER)
@@ -144,7 +144,7 @@ def get_parent_res(dggs: str, parent_res: Union[None, int], resolution: int) -> 
 
 
 def address_boundary_issues(
-    indexer: RasterIndexer,
+    indexer: IRasterIndexer,
     pq_input: tempfile.TemporaryDirectory,
     output: Path,
     resolution: int,

--- a/raster2dggs/indexerfactory.py
+++ b/raster2dggs/indexerfactory.py
@@ -2,7 +2,7 @@
 @author: ndemaio
 """
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.interfaces import IRasterIndexer
 
 import raster2dggs.indexers.h3rasterindexer as h3rasterindexer
 import raster2dggs.indexers.rhprasterindexer as rhprasterindexer
@@ -30,7 +30,7 @@ as defined in the list of click commands
 """
 
 
-def indexer_instance(dggs: str) -> RasterIndexer:
+def indexer_instance(dggs: str) -> IRasterIndexer:
     # Create and return appropriate indexer instance
     indexer = indexer_lookup[dggs]
     return indexer(dggs)

--- a/raster2dggs/indexers/a5rasterindexer.py
+++ b/raster2dggs/indexers/a5rasterindexer.py
@@ -16,17 +16,6 @@ import raster2dggs.constants as const
 from raster2dggs.interfaces import RasterIndexer
 
 
-def is_valid_a5_cell(cell: str, min_resolution: int, max_resolution: int):
-    cell = a5py.hex_to_u64(cell)
-    try:
-        c: a5py.A5Cell = a5py.core.serialization.deserialize(cell)
-    except TypeError:
-        return False
-    if not (min_resolution <= c["resolution"] <= max_resolution):
-        return False
-    return True
-
-
 class A5RasterIndexer(RasterIndexer):
     """
     Provides integration for the A5 DGGS.
@@ -48,8 +37,6 @@ class A5RasterIndexer(RasterIndexer):
 
         Implementation of interface function.
         """
-        PAD_WIDTH = const.zero_padding("a5")
-
         sdf: pd.DataFrame = (
             sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
         )
@@ -65,10 +52,10 @@ class A5RasterIndexer(RasterIndexer):
         # Secondary (parent) A5 index, used later for partitioning
         a5_parent = [a5py.cell_to_parent(cell, parent_res) for cell in cells]
         subset = subset.drop(columns=["x", "y"])
-        subset[f"a5_{resolution:0{PAD_WIDTH}d}"] = pd.Series(
-            map(a5py.u64_to_hex, cells), index=subset.index
-        )
-        subset[f"a5_{parent_res:0{PAD_WIDTH}d}"] = pd.Series(
+        index_col = self.index_col(resolution)
+        subset[index_col] = pd.Series(map(a5py.u64_to_hex, cells), index=subset.index)
+        partition_col = self.partition_col(parent_res)
+        subset[partition_col] = pd.Series(
             map(a5py.u64_to_hex, a5_parent), index=subset.index
         )
         # Renaming columns to actual band labels
@@ -77,45 +64,8 @@ class A5RasterIndexer(RasterIndexer):
         subset = subset.rename(columns=columns)
         return pa.Table.from_pandas(subset)
 
-    def parent_groupby(
-        self,
-        df,
-        resolution: int,
-        parent_res: int,
-        aggfunc: Union[str, Callable],
-        decimals: int,
-    ) -> pd.DataFrame:
-        """
-        Function for aggregating the A5 resolution values per parent partition. Each partition will be run through with a
-        pandas .groupby function. This step is to ensure there are no duplicate A5 values, which will happen when indexing a
-        high resolution raster at a coarser A5 resolution.
-
-        Implementation of interface function.
-        """
-        PAD_WIDTH = const.zero_padding("a5")
-        index_col = f"a5_{resolution:0{PAD_WIDTH}d}"
-        partition_col = f"a5_{parent_res:0{PAD_WIDTH}d}"
-        df = df.set_index(index_col)
-        if decimals > 0:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-            )
-        else:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-                .astype("Int64")
-            )
-        # Move parent out to a column; keep child as the index
-        # MultiIndex levels are [partition_col, index_col] in that order
-        gb = gb.reset_index(level=0)  # parent -> column
-        gb.index.name = index_col  # child remains index
-        return gb
-
-    def cell_to_children_size(self, cell: int, desired_resolution: int) -> int:
+    @staticmethod
+    def cell_to_children_size(cell: int, desired_resolution: int) -> int:
         """
         Determine total number of children at some offset resolution
 
@@ -124,53 +74,51 @@ class A5RasterIndexer(RasterIndexer):
         cell_level = a5py.get_resolution(cell)
         return 4 ** (desired_resolution - cell_level)
 
-    def compaction(
-        self, df: pd.DataFrame, resolution: int, parent_res: int
-    ) -> pd.DataFrame:
+    def valid_set(self, cells: set) -> set[str]:
         """
-        Returns a compacted version of the input dataframe.
-        Compaction only occurs if all values (i.e. bands) of the input share common values across all sibling cells.
-        Compaction will not be performed beyond parent_res or resolution.
-        It assumes and requires that the input has unique DGGS cell values as the index.
-
         Implementation of interface function.
         """
-        unprocessed_indices = set(
+        return set(
             filter(
                 lambda c: (not pd.isna(c))
-                and is_valid_a5_cell(c, parent_res, resolution),
-                set(df.index),
+                and self.is_valid_a5_cell(
+                    c,
+                ),
+                cells,
             ),
         )
-        if not unprocessed_indices:
-            return df
-        compaction_map = {}
-        for r in range(parent_res, resolution):
-            parent_cells = map(
-                a5py.u64_to_hex,
-                map(
-                    lambda x: a5py.cell_to_parent(x, r),
-                    map(a5py.hex_to_u64, unprocessed_indices),
-                ),
-            )
-            parent_groups = df.loc[list(unprocessed_indices)].groupby(
-                list(parent_cells)
-            )
-            for parent, group in parent_groups:
-                if isinstance(parent, tuple) and len(parent) == 1:
-                    parent = parent[0]
-                if parent in compaction_map:
-                    continue
-                expected_count = self.cell_to_children_size(
-                    a5py.hex_to_u64(parent), resolution
-                )
-                if len(group) == expected_count and all(group.nunique() == 1):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
-                    compaction_map[parent] = compact_row
-                    unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
-        remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
-        result_df = result_df.rename_axis(df.index.name)
-        return result_df
+
+    @staticmethod
+    def parent_cells(cells: set, resolution) -> map:
+        """
+        Implementation of interface function.
+        """
+        return map(
+            a5py.u64_to_hex,
+            map(
+                lambda x: a5py.cell_to_parent(x, resolution),
+                map(a5py.hex_to_u64, cells),
+            ),
+        )
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Implementation of interface function.
+        """
+        return self.cell_to_children_size(a5py.hex_to_u64(parent), resolution)
+
+    @staticmethod
+    def is_valid_a5_cell(
+        cell: str,
+    ) -> bool:
+        """
+        Returns cell validity.
+
+        Not a part of the RasterIndexer interface
+        """
+        cell = a5py.hex_to_u64(cell)
+        try:
+            c: a5py.A5Cell = a5py.core.serialization.deserialize(cell)
+        except TypeError:
+            return False
+        return True

--- a/raster2dggs/indexers/a5rasterindexer.py
+++ b/raster2dggs/indexers/a5rasterindexer.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
 
 
 class A5RasterIndexer(RasterIndexer):

--- a/raster2dggs/indexers/geohashrasterindexer.py
+++ b/raster2dggs/indexers/geohashrasterindexer.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
 
 
 class GeohashRasterIndexer(RasterIndexer):

--- a/raster2dggs/indexers/h3rasterindexer.py
+++ b/raster2dggs/indexers/h3rasterindexer.py
@@ -60,7 +60,12 @@ class H3RasterIndexer(RasterIndexer):
         return pa.Table.from_pandas(h3index)
 
     def parent_groupby(
-        self, df, resolution: int, aggfunc: Union[str, Callable], decimals: int
+        self,
+        df,
+        resolution: int,
+        parent_res: int,
+        aggfunc: Union[str, Callable],
+        decimals: int,
     ) -> pd.DataFrame:
         """
         Function for aggregating the H3 resolution values per parent partition. Each partition will be run through with a
@@ -70,21 +75,27 @@ class H3RasterIndexer(RasterIndexer):
         Implementation of interface function.
         """
         PAD_WIDTH = const.zero_padding("h3")
-
-        print(df)
+        index_col = f"h3_{resolution:0{PAD_WIDTH}d}"
+        partition_col = f"h3_{parent_res:0{PAD_WIDTH}d}"
+        df = df.set_index(index_col)
         if decimals > 0:
-            return (
-                df.groupby(f"h3_{resolution:0{PAD_WIDTH}d}")
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
                 .agg(aggfunc)
                 .round(decimals)
             )
         else:
-            return (
-                df.groupby(f"h3_{resolution:0{PAD_WIDTH}d}")
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
                 .agg(aggfunc)
                 .round(decimals)
                 .astype("Int64")
             )
+        # Move parent out to a column; keep child as the index
+        # MultiIndex levels are [partition_col, index_col] in that order
+        gb = gb.reset_index(level=0)  # parent -> column
+        gb.index.name = index_col  # child remains index
+        return gb
 
     def cell_to_children_size(self, cell, desired_resolution: int) -> int:
         """

--- a/raster2dggs/indexers/h3rasterindexer.py
+++ b/raster2dggs/indexers/h3rasterindexer.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
 
 
 class H3RasterIndexer(RasterIndexer):

--- a/raster2dggs/indexers/h3rasterindexer.py
+++ b/raster2dggs/indexers/h3rasterindexer.py
@@ -59,45 +59,8 @@ class H3RasterIndexer(RasterIndexer):
         h3index = h3index.rename(columns=columns)
         return pa.Table.from_pandas(h3index)
 
-    def parent_groupby(
-        self,
-        df,
-        resolution: int,
-        parent_res: int,
-        aggfunc: Union[str, Callable],
-        decimals: int,
-    ) -> pd.DataFrame:
-        """
-        Function for aggregating the H3 resolution values per parent partition. Each partition will be run through with a
-        pandas .groupby function. This step is to ensure there are no duplicate H3 values, which will happen when indexing a
-        high resolution raster at a coarser H3 resolution.
-
-        Implementation of interface function.
-        """
-        PAD_WIDTH = const.zero_padding("h3")
-        index_col = f"h3_{resolution:0{PAD_WIDTH}d}"
-        partition_col = f"h3_{parent_res:0{PAD_WIDTH}d}"
-        df = df.set_index(index_col)
-        if decimals > 0:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-            )
-        else:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-                .astype("Int64")
-            )
-        # Move parent out to a column; keep child as the index
-        # MultiIndex levels are [partition_col, index_col] in that order
-        gb = gb.reset_index(level=0)  # parent -> column
-        gb.index.name = index_col  # child remains index
-        return gb
-
-    def cell_to_children_size(self, cell, desired_resolution: int) -> int:
+    @staticmethod
+    def cell_to_children_size(cell, desired_resolution: int) -> int:
         """
         Determine total number of children at some offset resolution
 
@@ -110,41 +73,22 @@ class H3RasterIndexer(RasterIndexer):
         else:
             return 7**n
 
-    def compaction(
-        self, df: pd.DataFrame, resolution: int, parent_res: int
-    ) -> pd.DataFrame:
+    @staticmethod
+    def valid_set(cells: set) -> set[str]:
         """
-        Returns a compacted version of the input dataframe.
-        Compaction only occurs if all values (i.e. bands) of the input share common values across all sibling cells.
-        Compaction will not be performed beyond parent_res or resolution.
-        It assumes and requires that the input has unique DGGS cell values as the index.
-
         Implementation of interface function.
         """
-        unprocessed_indices = set(
-            filter(lambda c: (not pd.isna(c)) and h3py.is_valid_cell(c), set(df.index))
-        )
-        if not unprocessed_indices:
-            return df
-        compaction_map = {}
-        for r in range(parent_res, resolution):
-            parent_cells = map(lambda x: h3py.cell_to_parent(x, r), unprocessed_indices)
-            parent_groups = df.loc[list(unprocessed_indices)].groupby(
-                list(parent_cells)
-            )
-            for parent, group in parent_groups:
-                if isinstance(parent, tuple) and len(parent) == 1:
-                    parent = parent[0]
-                if parent in compaction_map:
-                    continue
-                expected_count = self.cell_to_children_size(parent, resolution)
-                if len(group) == expected_count and all(group.nunique() == 1):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
-                    compaction_map[parent] = compact_row
-                    unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
-        remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
-        result_df = result_df.rename_axis(df.index.name)
-        return result_df
+        return set(filter(lambda c: (not pd.isna(c)) and h3py.is_valid_cell(c), cells))
+
+    @staticmethod
+    def parent_cells(cells: set, resolution) -> map:
+        """
+        Implementation of interface function.
+        """
+        return map(lambda x: h3py.cell_to_parent(x, resolution), cells)
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Implementation of interface function.
+        """
+        return self.cell_to_children_size(parent, resolution)

--- a/raster2dggs/indexers/maidenheadrasterindexer.py
+++ b/raster2dggs/indexers/maidenheadrasterindexer.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
 
 
 class MaidenheadRasterIndexer(RasterIndexer):

--- a/raster2dggs/indexers/maidenheadrasterindexer.py
+++ b/raster2dggs/indexers/maidenheadrasterindexer.py
@@ -37,8 +37,6 @@ class MaidenheadRasterIndexer(RasterIndexer):
 
         Implementation of interface function.
         """
-        PAD_WIDTH = const.zero_padding("maidenhead")
-
         sdf: pd.DataFrame = (
             sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
         )
@@ -57,56 +55,18 @@ class MaidenheadRasterIndexer(RasterIndexer):
             self.cell_to_parent(mh, parent_precision) for mh in maidenhead
         ]
         subset = subset.drop(columns=["x", "y"])
-        subset[f"maidenhead_{precision:0{PAD_WIDTH}d}"] = pd.Series(
-            maidenhead, index=subset.index
-        )
-        subset[f"maidenhead_{parent_precision:0{PAD_WIDTH}d}"] = pd.Series(
-            maidenhead_parent, index=subset.index
-        )
+        index_col = self.index_col(precision)
+        subset[index_col] = pd.Series(maidenhead, index=subset.index)
+        partition_col = self.partition_col(parent_precision)
+        subset[partition_col] = pd.Series(maidenhead_parent, index=subset.index)
         # Rename bands
         bands = sdf["band"].unique()
         columns = dict(zip(bands, band_labels))
         subset = subset.rename(columns=columns)
         return pa.Table.from_pandas(subset)
 
-    def parent_groupby(
-        self,
-        df,
-        precision: int,
-        parent_precision: int,
-        aggfunc: Union[str, Callable],
-        decimals: int,
-    ) -> pd.DataFrame:
-        """
-        Function for aggregating the Maidenhead values per parent partition. Each partition will be run through with a
-        pandas .groupby function. This step is to ensure there are no duplicate Maidenhead indices, which will certainly happen when indexing most raster datasets as Maidenhead has low precision.
-
-        Implementation of interface function.
-        """
-        PAD_WIDTH = const.zero_padding("maidenhead")
-        index_col = f"maidenhead_{precision:0{PAD_WIDTH}d}"
-        partition_col = f"maidenhead_{parent_precision:0{PAD_WIDTH}d}"
-        df = df.set_index(index_col)
-        if decimals > 0:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-            )
-        else:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-                .astype("Int64")
-            )
-        # Move parent out to a column; keep child as the index
-        # MultiIndex levels are [partition_col, index_col] in that order
-        gb = gb.reset_index(level=0)  # parent -> column
-        gb.index.name = index_col  # child remains index
-        return gb
-
-    def cell_to_children_size(self, cell, desired_level: int) -> int:
+    @staticmethod
+    def cell_to_children_size(cell, desired_level: int) -> int:
         """
         Determine total number of children at some offset level.
 
@@ -117,48 +77,27 @@ class MaidenheadRasterIndexer(RasterIndexer):
             return 0
         return 100 ** (desired_level - level)
 
-    def compaction(
-        self, df: pd.DataFrame, level: int, parent_level: int
-    ) -> pd.DataFrame:
+    @staticmethod
+    def valid_set(cells: set) -> set[str]:
         """
-        Returns a compacted version of the input dataframe.
-        Compaction only occurs if all values (i.e. bands) of the input share common values across all sibling cells.
-        Compaction will not be performed beyond parent_level or level.
-        It assumes and requires that the input has unique DGGS cell values as the index.
-
         Implementation of interface function.
         """
-        unprocessed_indices = set(
-            filter(lambda c: not pd.isna(c) and len(c) >= 2, set(df.index))
-        )
-        if not unprocessed_indices:
-            return df
-        compaction_map = {}
-        for l in range(parent_level, level):
-            parent_cells = list(
-                map(lambda x: self.cell_to_parent(x, l), unprocessed_indices)
-            )
-            parent_groups = df.loc[list(unprocessed_indices)].groupby(
-                list(parent_cells)
-            )
-            for parent, group in parent_groups:
-                if isinstance(parent, tuple) and len(parent) == 1:
-                    parent = parent[0]
-                if parent in compaction_map:
-                    continue
-                expected_count = self.cell_to_children_size(parent, level)
-                if len(group) == expected_count and all(group.nunique() == 1):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
-                    compaction_map[parent] = compact_row
-                    unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
-        remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
-        result_df = result_df.rename_axis(df.index.name)
-        return result_df
+        return set(filter(lambda c: not pd.isna(c) and len(c) >= 2, cells))
 
-    def cell_to_parent(self, cell: str, parent_level: int) -> str:
+    def parent_cells(self, cells: set, resolution) -> map:
+        """
+        Implementation of interface function.
+        """
+        return map(lambda x: self.cell_to_parent(x, resolution), cells)
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Implementation of interface function.
+        """
+        return self.cell_to_children_size(parent, resolution)
+
+    @staticmethod
+    def cell_to_parent(cell: str, parent_level: int) -> str:
         """
         Returns cell parent at some offset level.
 

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -1,0 +1,160 @@
+"""
+@author: ndemaio
+"""
+
+from numbers import Number
+from typing import Callable, Tuple, Union
+
+import pandas as pd
+import pyarrow as pa
+import xarray as xr
+import numpy as np
+
+from .. import constants as const
+from .. interfaces import IRasterIndexer
+
+
+class RasterIndexer(IRasterIndexer):
+    """
+    Provides a partial implementation for raster indexers integrating a
+        specific DGGS. It should never be instantiated directly because
+        many methods raise a NotImplementedError by design. The methods
+        should be implemented by the child classes deriving from this
+        interface instead.
+        If specialised behaviour is required, methods may be
+        re-implemented by derived classes.
+    """
+
+    def __init__(self, dggs: str):
+        """
+        Value used across all child classes
+        """
+        self.dggs = dggs
+
+    def index_col(self, resolution):
+        pad_width = const.zero_padding(self.dggs)
+        return f"{self.dggs}_{resolution:0{pad_width}d}"
+
+    def partition_col(self, parent_resolution):
+        pad_width = const.zero_padding(self.dggs)
+        return f"{self.dggs}_{parent_resolution:0{pad_width}d}"
+
+    def band_cols(self, df: pd.DataFrame):
+        return [c for c in df.columns if not c.startswith(f"{self.dggs}_")]
+
+    @staticmethod
+    def valid_set(cells: set) -> set:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def parent_cells(cells: set, resolution) -> map:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError
+
+    def index_func(
+        self,
+        sdf: xr.DataArray,
+        resolution: int,
+        parent_res: int,
+        nodata: Number = np.nan,
+        band_labels: Tuple[str] = None,
+    ) -> pa.Table:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError()
+
+    def parent_groupby(
+        self,
+        df,
+        resolution: int,
+        parent_res: int,
+        aggfunc: Union[str, Callable],
+        decimals: int,
+    ) -> pd.DataFrame:
+        """
+        Function for aggregating the DGGS resolution values per parent
+            partition. Each partition will be run through with a pandas
+            groupby function. This step is to ensure there are no duplicate
+            cell values, which will happen when indexing a high resolution
+            raster at a coarser DGGS resolution.
+        """
+        index_col = self.index_col(resolution)
+        partition_col = self.partition_col(parent_res)
+        df = df.set_index(index_col)
+        if decimals > 0:
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
+                .agg(aggfunc)
+                .round(decimals)
+            )
+        else:
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
+                .agg(aggfunc)
+                .round(decimals)
+                .astype("Int64")
+            )
+        # Move parent out to a column; keep child as the index
+        # MultiIndex levels are [partition_col, index_col] in that order
+        gb = gb.reset_index(level=0)  # parent -> column
+        gb.index.name = index_col  # child remains index
+        return gb
+
+    @staticmethod
+    def cell_to_children_size(cell, desired_resolution: int) -> int:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError()
+
+    def compaction(
+        self, df: pd.DataFrame, resolution: int, parent_res: int
+    ) -> pd.DataFrame:
+        """
+        Returns a compacted version of the input dataframe.
+        Compaction only occurs if all values (i.e. bands) of the input
+            share common values across all sibling cells.
+        Compaction will not be performed beyond parent_res.
+        It assumes that the input has unique DGGS cell values
+            as the index.
+        """
+        unprocessed_indices = self.valid_set(set(df.index))
+        if not unprocessed_indices:
+            return df
+        band_cols = self.band_cols(df)
+        compaction_map = {}
+        for r in range(parent_res, resolution):
+            parent_cells = self.parent_cells(unprocessed_indices, r)
+            parent_groups = df.loc[list(unprocessed_indices)].groupby(
+                list(parent_cells)
+            )
+            for parent, group in parent_groups:
+                if isinstance(parent, tuple) and len(parent) == 1:
+                    parent = parent[0]
+                if parent in compaction_map:
+                    continue
+                expected_count = self.expected_count(parent, resolution)
+                if len(group) == expected_count and all(
+                    group[band_cols].nunique() == 1
+                ):
+                    compact_row = group.iloc[0]
+                    compact_row.name = parent  # Rename the index to the parent cell
+                    compaction_map[parent] = compact_row
+                    unprocessed_indices -= set(group.index)
+        compacted_df = pd.DataFrame(list(compaction_map.values()))
+        remaining_df = df.loc[list(unprocessed_indices)]
+        result_df = pd.concat([compacted_df, remaining_df])
+        result_df = result_df.rename_axis(df.index.name)
+        return result_df

--- a/raster2dggs/indexers/rhprasterindexer.py
+++ b/raster2dggs/indexers/rhprasterindexer.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
 
 
 class RHPRasterIndexer(RasterIndexer):

--- a/raster2dggs/indexers/s2rasterindexer.py
+++ b/raster2dggs/indexers/s2rasterindexer.py
@@ -37,8 +37,6 @@ class S2RasterIndexer(RasterIndexer):
 
         Implementation of interface function.
         """
-        PAD_WIDTH = const.zero_padding("s2")
-
         sdf: pd.DataFrame = (
             sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
         )
@@ -55,55 +53,18 @@ class S2RasterIndexer(RasterIndexer):
         s2 = [cell.parent(resolution).to_token() for cell in cells]
         s2_parent = [cell.parent(parent_res).to_token() for cell in cells]
         subset = subset.drop(columns=["x", "y"])
-        subset[f"s2_{resolution:0{PAD_WIDTH}d}"] = pd.Series(s2, index=subset.index)
-        subset[f"s2_{parent_res:0{PAD_WIDTH}d}"] = pd.Series(
-            s2_parent, index=subset.index
-        )
+        index_col = self.index_col(resolution)
+        subset[index_col] = pd.Series(s2, index=subset.index)
+        partition_col = self.partition_col(parent_res)
+        subset[partition_col] = pd.Series(s2_parent, index=subset.index)
         # Renaming columns to actual band labels
         bands = sdf["band"].unique()
         columns = dict(zip(bands, band_labels))
         subset = subset.rename(columns=columns)
         return pa.Table.from_pandas(subset)
 
-    def parent_groupby(
-        self,
-        df: pd.DataFrame,
-        resolution: int,
-        parent_res: int,
-        aggfunc: Union[str, Callable],
-        decimals: int,
-    ) -> pd.DataFrame:
-        """
-        Function for aggregating the S2 resolution values per parent partition. Each partition will be run through with a
-        pandas .groupby function. This step is to ensure there are no duplicate S2 values, which will happen when indexing a
-        high resolution raster at a coarser S2 resolution.
-
-        Implementation of interface function.
-        """
-        PAD_WIDTH = const.zero_padding("s2")
-        index_col = f"s2_{resolution:0{PAD_WIDTH}d}"
-        partition_col = f"s2_{parent_res:0{PAD_WIDTH}d}"
-        df = df.set_index(index_col)
-        if decimals > 0:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-            )
-        else:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-                .astype("Int64")
-            )
-        # Move parent out to a column; keep child as the index
-        # MultiIndex levels are [partition_col, index_col] in that order
-        gb = gb.reset_index(level=0)  # parent -> column
-        gb.index.name = index_col  # child remains index
-        return gb
-
-    def cell_to_children_size(self, cell, desired_resolution: int) -> int:
+    @staticmethod
+    def cell_to_children_size(cell, desired_resolution: int) -> int:
         """
         Determine total number of children at some offset resolution
 
@@ -118,55 +79,36 @@ class S2RasterIndexer(RasterIndexer):
         # For levels greater than 0, the cell divides into 4^(n-m) children
         return 4 ** (desired_resolution - cell_level)
 
-    def compaction(
-        self, df: pd.DataFrame, resolution: int, parent_res: int
-    ) -> pd.DataFrame:
+    @staticmethod
+    def valid_set(cells: set) -> set[str]:
         """
-        Returns a compacted version of the input dataframe.
-        Compaction only occurs if all values (i.e. bands) of the input share common values across all sibling cells.
-        Compaction will not be performed beyond parent_res or resolution.
-        It assumes and requires that the input has unique DGGS cell values as the index.
-
         Implementation of interface function.
         """
-        unprocessed_indices = set(
+        return set(
             map(
                 lambda c: c.to_token(),
                 filter(
                     lambda c: c.is_valid(),
                     map(
                         lambda c: CellId.from_token(c),
-                        filter(lambda c: not pd.isna(c), set(df.index)),
+                        filter(lambda c: not pd.isna(c), cells),
                     ),
                 ),
             )
         )
-        if not unprocessed_indices:
-            return df
-        compaction_map = {}
-        for r in range(parent_res, resolution):
-            parent_cells = map(
-                lambda token: CellId.from_token(token).parent(r).to_token(),
-                unprocessed_indices,
-            )
-            parent_groups = df.loc[list(unprocessed_indices)].groupby(
-                list(parent_cells)
-            )
-            for parent, group in parent_groups:
-                if isinstance(parent, tuple) and len(parent) == 1:
-                    parent = parent[0]
-                if parent in compaction_map:
-                    continue
-                expected_count = self.cell_to_children_size(
-                    CellId.from_token(parent), resolution
-                )
-                if len(group) == expected_count and all(group.nunique() == 1):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
-                    compaction_map[parent] = compact_row
-                    unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
-        remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
-        result_df = result_df.rename_axis(df.index.name)
-        return result_df
+
+    @staticmethod
+    def parent_cells(cells: set, resolution) -> map:
+        """
+        Implementation of interface function.
+        """
+        return map(
+            lambda token: CellId.from_token(token).parent(resolution).to_token(),
+            cells,
+        )
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Implementation of interface function.
+        """
+        return self.cell_to_children_size(CellId.from_token(parent), resolution)

--- a/raster2dggs/indexers/s2rasterindexer.py
+++ b/raster2dggs/indexers/s2rasterindexer.py
@@ -13,7 +13,8 @@ import numpy as np
 
 import raster2dggs.constants as const
 
-from raster2dggs.interfaces import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer
+
 
 
 class S2RasterIndexer(RasterIndexer):

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -13,15 +13,13 @@ import numpy as np
 from . import constants as const
 
 
-class RasterIndexer:
+class IRasterIndexer:
     """
     Provides a base class and interface for all indexers integrating a
         specific DGGS. It should never be instantiated directly because
-        many methods raise a NotImplementedError by design. The methods
+        all methods raise a NotImplementedError by design. The methods
         should be implemented by the child classes deriving from this
         interface instead.
-        If specialised behaviour is required, methods may be
-        re-implemented by derived classes.
     """
 
     def __init__(self, dggs: str):
@@ -30,34 +28,45 @@ class RasterIndexer:
         """
         self.dggs = dggs
 
-    def index_col(self, resolution):
-        pad_width = const.zero_padding(self.dggs)
-        return f"{self.dggs}_{resolution:0{pad_width}d}"
-
-    def partition_col(self, parent_resolution):
-        pad_width = const.zero_padding(self.dggs)
-        return f"{self.dggs}_{parent_resolution:0{pad_width}d}"
-
-    def band_cols(self, df: pd.DataFrame):
-        return [c for c in df.columns if not c.startswith(f"{self.dggs}_")]
-
-    @staticmethod
-    def valid_set(cells: set) -> set:
+    def index_col(self, resolution : int) -> str:
         """
-        Needs to be implemented by child class
+        Returns the primary DGGS index column name, with zero padding so that column
+        names across a DGGS' full resolution space have the same length.
+        """
+        raise NotImplementedError()
+
+    def partition_col(self, parent_resolution : int) -> str:
+        """
+        Returns the partition DGGS index column name, with zero padding so that column
+        names across a DGGS' full resolution space have the same length.
+        """
+        raise NotImplementedError()
+
+    def band_cols(self, df: pd.DataFrame) -> list[str]:
+        """
+        Returns the column names representing raster bands from an input image.
         """
         raise NotImplementedError()
 
     @staticmethod
-    def parent_cells(cells: set, resolution) -> map:
+    def valid_set(cells: set) -> set:
         """
-        Needs to be implemented by child class
+        Given a set of DGGS cells of the same DGGS return the subset that are valid cell addresses.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def parent_cells(cells: set, resolution: int) -> map:
+        """
+        Given a set of DGGS cells, return an iterable of parent cells at given resolution 
         """
         raise NotImplementedError
 
-    def expected_count(self, parent: str, resolution: int):
+    def expected_count(self, parent: str, resolution: int) -> int:
         """
-        Needs to be implemented by child class
+        Given a DGGS (parent) cell ID, and a target (child) resolution,
+        return the expected number of child cells that completel represent this
+        parent cell at the target resolution.
         """
         raise NotImplementedError
 
@@ -70,7 +79,7 @@ class RasterIndexer:
         band_labels: Tuple[str] = None,
     ) -> pa.Table:
         """
-        Needs to be implemented by child class
+        Function for primary indexation.
         """
         raise NotImplementedError()
 
@@ -89,27 +98,7 @@ class RasterIndexer:
             cell values, which will happen when indexing a high resolution
             raster at a coarser DGGS resolution.
         """
-        index_col = self.index_col(resolution)
-        partition_col = self.partition_col(parent_res)
-        df = df.set_index(index_col)
-        if decimals > 0:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-            )
-        else:
-            gb = (
-                df.groupby([partition_col, index_col], sort=False, observed=True)
-                .agg(aggfunc)
-                .round(decimals)
-                .astype("Int64")
-            )
-        # Move parent out to a column; keep child as the index
-        # MultiIndex levels are [partition_col, index_col] in that order
-        gb = gb.reset_index(level=0)  # parent -> column
-        gb.index.name = index_col  # child remains index
-        return gb
+        raise NotImplementedError
 
     @staticmethod
     def cell_to_children_size(cell, desired_resolution: int) -> int:
@@ -129,31 +118,4 @@ class RasterIndexer:
         It assumes that the input has unique DGGS cell values
             as the index.
         """
-        unprocessed_indices = self.valid_set(set(df.index))
-        if not unprocessed_indices:
-            return df
-        band_cols = self.band_cols(df)
-        compaction_map = {}
-        for r in range(parent_res, resolution):
-            parent_cells = self.parent_cells(unprocessed_indices, r)
-            parent_groups = df.loc[list(unprocessed_indices)].groupby(
-                list(parent_cells)
-            )
-            for parent, group in parent_groups:
-                if isinstance(parent, tuple) and len(parent) == 1:
-                    parent = parent[0]
-                if parent in compaction_map:
-                    continue
-                expected_count = self.expected_count(parent, resolution)
-                if len(group) == expected_count and all(
-                    group[band_cols].nunique() == 1
-                ):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
-                    compaction_map[parent] = compact_row
-                    unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
-        remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
-        result_df = result_df.rename_axis(df.index.name)
-        return result_df
+        raise NotImplementedError()

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -10,14 +10,18 @@ import pyarrow as pa
 import xarray as xr
 import numpy as np
 
+from . import constants as const
+
 
 class RasterIndexer:
     """
-    Provides a base class and interface for all indexers integrating a specific
-    DGGS. It should never be instantiated directly because all methods raise
-    a NotImplementedError by design - the only thing that's not abstract is
-    the DGGS name string as defined in the click command. The methods should
-    be implemented by the child classes deriving from this interface instead.
+    Provides a base class and interface for all indexers integrating a
+        specific DGGS. It should never be instantiated directly because
+        many methods raise a NotImplementedError by design. The methods
+        should be implemented by the child classes deriving from this
+        interface instead.
+        If specialised behaviour is required, methods may be
+        re-implemented by derived classes.
     """
 
     def __init__(self, dggs: str):
@@ -25,6 +29,37 @@ class RasterIndexer:
         Value used across all child classes
         """
         self.dggs = dggs
+
+    def index_col(self, resolution):
+        pad_width = const.zero_padding(self.dggs)
+        return f"{self.dggs}_{resolution:0{pad_width}d}"
+
+    def partition_col(self, parent_resolution):
+        pad_width = const.zero_padding(self.dggs)
+        return f"{self.dggs}_{parent_resolution:0{pad_width}d}"
+
+    def band_cols(self, df: pd.DataFrame):
+        return [c for c in df.columns if not c.startswith(f"{self.dggs}_")]
+
+    @staticmethod
+    def valid_set(cells: set) -> set:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def parent_cells(cells: set, resolution) -> map:
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError
+
+    def expected_count(self, parent: str, resolution: int):
+        """
+        Needs to be implemented by child class
+        """
+        raise NotImplementedError
 
     def index_func(
         self,
@@ -40,14 +75,44 @@ class RasterIndexer:
         raise NotImplementedError()
 
     def parent_groupby(
-        self, df, resolution: int, aggfunc: Union[str, Callable], decimals: int
+        self,
+        df,
+        resolution: int,
+        parent_res: int,
+        aggfunc: Union[str, Callable],
+        decimals: int,
     ) -> pd.DataFrame:
         """
-        Needs to be implemented by child class
+        Function for aggregating the DGGS resolution values per parent
+            partition. Each partition will be run through with a pandas
+            groupby function. This step is to ensure there are no duplicate
+            cell values, which will happen when indexing a high resolution
+            raster at a coarser DGGS resolution.
         """
-        raise NotImplementedError()
+        index_col = self.index_col(resolution)
+        partition_col = self.partition_col(parent_res)
+        df = df.set_index(index_col)
+        if decimals > 0:
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
+                .agg(aggfunc)
+                .round(decimals)
+            )
+        else:
+            gb = (
+                df.groupby([partition_col, index_col], sort=False, observed=True)
+                .agg(aggfunc)
+                .round(decimals)
+                .astype("Int64")
+            )
+        # Move parent out to a column; keep child as the index
+        # MultiIndex levels are [partition_col, index_col] in that order
+        gb = gb.reset_index(level=0)  # parent -> column
+        gb.index.name = index_col  # child remains index
+        return gb
 
-    def cell_to_children_size(self, cell, desired_resolution: int) -> int:
+    @staticmethod
+    def cell_to_children_size(cell, desired_resolution: int) -> int:
         """
         Needs to be implemented by child class
         """
@@ -57,6 +122,38 @@ class RasterIndexer:
         self, df: pd.DataFrame, resolution: int, parent_res: int
     ) -> pd.DataFrame:
         """
-        Needs to be implemented by child class
+        Returns a compacted version of the input dataframe.
+        Compaction only occurs if all values (i.e. bands) of the input
+            share common values across all sibling cells.
+        Compaction will not be performed beyond parent_res.
+        It assumes that the input has unique DGGS cell values
+            as the index.
         """
-        raise NotImplementedError()
+        unprocessed_indices = self.valid_set(set(df.index))
+        if not unprocessed_indices:
+            return df
+        band_cols = self.band_cols(df)
+        compaction_map = {}
+        for r in range(parent_res, resolution):
+            parent_cells = self.parent_cells(unprocessed_indices, r)
+            parent_groups = df.loc[list(unprocessed_indices)].groupby(
+                list(parent_cells)
+            )
+            for parent, group in parent_groups:
+                if isinstance(parent, tuple) and len(parent) == 1:
+                    parent = parent[0]
+                if parent in compaction_map:
+                    continue
+                expected_count = self.expected_count(parent, resolution)
+                if len(group) == expected_count and all(
+                    group[band_cols].nunique() == 1
+                ):
+                    compact_row = group.iloc[0]
+                    compact_row.name = parent  # Rename the index to the parent cell
+                    compaction_map[parent] = compact_row
+                    unprocessed_indices -= set(group.index)
+        compacted_df = pd.DataFrame(list(compaction_map.values()))
+        remaining_df = df.loc[list(unprocessed_indices)]
+        result_df = pd.concat([compacted_df, remaining_df])
+        result_df = result_df.rename_axis(df.index.name)
+        return result_df


### PR DESCRIPTION
Closes #38 

- Considerably improves performance by avoiding an expensive re-partitioning.
- Is a "slight" breaking change.

Old output:

```bash
tree ~/Documents/sen2-h3-brotli-co.pq

/home/richard/Doocuments/sen2-h3-brotli-co.pq
├── 83bb09fffffffff.parquet
│   └── part.0.parquet
└── 83bb0dfffffffff.parquet
    └── part.0.parquet
```

New output:

```bash
tree ~/Doocuments/sen2-h3-brotli-co.pq

/home/richard/Doocuments/sen2-h3-brotli-co.pq
├── h3_03=83bb09fffffffff
│   └── part.0.parquet
└── h3_03=83bb0dfffffffff
    └── part.0.parquet
```

Now, if you read the whole .pq file, you will now see an additional `h3_03` column (or equivalent parent col), whereas before this was absent, it was only _implicit_ in the subdirectory name.