### PR TITLE
closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Options:
                                   numeric indices (1-based indexing) or string
                                   band labels (if present in the input), e.g.
                                   -b B02 -b B07 -b B12.
+  --nodata_policy [skip|emit]     'skip' omits nodata cells from output
+                                  (default). 'emit' includes them, writing the
+                                  source raster nodata value (or
+                                  --emit_nodata_value if set). Note: non-NaN
+                                  emitted values participate in cell
+                                  aggregation (see -a/--aggfunc); if this is
+                                  undesired, ensure your source nodata is NaN
+                                  or override with --emit_nodata_value.
+                                  [default: skip]
+  --emit_nodata_value NUMBER      Override the value written for nodata cells
+                                  when --nodata_policy=emit. If omitted, the
+                                  source raster nodata value is used (NaN if
+                                  none is defined). Pass 'nan' to explicitly
+                                  emit NaN. Coerced to the output dtype. Note:
+                                  non-NaN values participate in cell
+                                  aggregation (see -a/--aggfunc).
   -u, --upscale INTEGER           Upscaling factor, used to upsample input
                                   data on the fly; useful when the raster
                                   resolution is lower than the target DGGS
@@ -304,8 +320,7 @@ Please run `black .` before committing.
 Tests are included. To run them, set up a poetry environment, then follow these instructons:
 
 ```bash
-cd tests
-python ./test_raster2dggs.py
+python tests/test_raster2dggs.py
 ```
 
 Test data are included at `tests/data/`.

--- a/make_samples.py
+++ b/make_samples.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Generate a small suite of synthetic thematic GeoTIFF rasters with differing
+"semantics" and nodata complexities for testing Raster→DGGS tooling.
+
+Outputs (by default in ./sample_rasters):
+  1) landcover_utm33.tif          (categorical, piecewise-constant, nodata holes/stripe)
+  2) frac_treecover_utm33.tif     (fractional cover 0..1, nodata coast-like mask)
+  3) popcount_webmerc.tif         (count_total, mass-in-cell, skewed totals, nodata polygon)
+  4) temp_mean_wgs84.tif          (cell_average-like continuous, geographic CRS, nodata band)
+  5) zone_ids_laea.tif            (categorical zones, large polygons + small islands, nodata)
+
+Neutral landscape models (NLMs): uses smoothed noise (fractal-ish via multi-octave
+upsampling + Gaussian smoothing) to create spatial autocorrelation.
+
+Dependencies: numpy, rasterio
+Optional: scipy (for gaussian filter). If scipy isn't installed, a simple box blur fallback is used.
+
+Usage:
+  python make_sample_rasters.py --outdir sample_rasters --seed 7
+"""
+
+import os
+import argparse
+import math
+import numpy as np
+
+import rasterio
+from rasterio.transform import from_origin
+from rasterio.crs import CRS
+
+try:
+    from scipy.ndimage import gaussian_filter
+    HAVE_SCIPY = True
+except Exception:
+    HAVE_SCIPY = False
+
+
+def box_blur(img, k=5, passes=2):
+    """Fallback blur if scipy isn't available. Crude but OK for test rasters."""
+    out = img.astype(np.float32)
+    pad = k // 2
+    for _ in range(passes):
+        padded = np.pad(out, pad, mode="edge")
+        acc = np.zeros_like(out, dtype=np.float32)
+        for dy in range(k):
+            for dx in range(k):
+                acc += padded[dy:dy + out.shape[0], dx:dx + out.shape[1]]
+        out = acc / (k * k)
+    return out
+
+
+def smooth(img, sigma):
+    if HAVE_SCIPY:
+        return gaussian_filter(img, sigma=sigma, mode="nearest")
+    # approximate sigma with a box kernel size
+    k = max(3, int(round(sigma * 3)) | 1)  # odd
+    passes = 2
+    return box_blur(img, k=k, passes=passes)
+
+
+def nlm_fractal(shape, rng, octaves=5, persistence=0.55):
+    """
+    Simple multi-octave smooth noise producing spatial autocorrelation.
+    Returns float32 in ~[0,1].
+    """
+    h, w = shape
+    field = np.zeros((h, w), dtype=np.float32)
+    amp = 1.0
+    amp_sum = 0.0
+
+    for o in range(octaves):
+        step = 2 ** (octaves - o - 1)
+
+        # CEIL so that coarse.repeat(step) is >= target size
+        ch = max(2, int(math.ceil(h / step)))
+        cw = max(2, int(math.ceil(w / step)))
+
+        coarse = rng.random((ch, cw), dtype=np.float32)
+
+        up = coarse.repeat(step, axis=0).repeat(step, axis=1)
+        up = up[:h, :w]  # safe now: up is guaranteed >= (h,w)
+
+        up = smooth(up, sigma=max(1.0, step / 2.5))
+
+        field += amp * up
+        amp_sum += amp
+        amp *= persistence
+
+    field /= max(amp_sum, 1e-9)
+    lo, hi = np.percentile(field, [1, 99])
+    field = np.clip((field - lo) / (hi - lo + 1e-9), 0, 1).astype(np.float32)
+    return field
+
+
+
+def write_geotiff(path, data, crs, transform, nodata=None, dtype=None, tags=None):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if data.ndim == 2:
+        data = data[np.newaxis, ...]  # (bands, h, w)
+    bands, h, w = data.shape
+    if dtype is None:
+        dtype = data.dtype
+
+    profile = {
+        "driver": "GTiff",
+        "height": h,
+        "width": w,
+        "count": bands,
+        "dtype": dtype,
+        "crs": crs,
+        "transform": transform,
+        "compress": "deflate",
+        "predictor": 2 if np.issubdtype(np.dtype(dtype), np.floating) else 1,
+        "tiled": True,
+        "blockxsize": 256 if w >= 256 else w,
+        "blockysize": 256 if h >= 256 else h,
+    }
+    if nodata is not None:
+        profile["nodata"] = nodata
+
+    with rasterio.open(path, "w", **profile) as dst:
+        for b in range(bands):
+            dst.write(data[b].astype(dtype), b + 1)
+        if tags:
+            dst.update_tags(**tags)
+
+
+def make_landcover_piecewise_constant(outdir, rng):
+    """
+    Categorical landcover (classes 1..6), with nodata holes and a nodata stripe.
+    CRS: UTM zone 33N (EPSG:32633) somewhere near N Italy / Alps.
+    """
+    crs = CRS.from_epsg(32633)
+    w, h = 512, 512
+    px = 30.0  # 30 m
+    # place upper-left roughly near (E=500000, N=5100000)
+    transform = from_origin(500000.0, 5100000.0, px, px)
+
+    f = nlm_fractal((h, w), rng, octaves=6, persistence=0.58)
+    # skew distribution so classes occupy uneven areas
+    g = np.clip(f ** 1.7, 0, 1)
+
+    # quantize into 6 classes
+    bins = np.quantile(g, [0.12, 0.28, 0.50, 0.72, 0.88])
+    classes = np.digitize(g, bins).astype(np.uint8) + 1  # 1..6
+
+    nodata = 0
+    # nodata "lakes" (holes)
+    holes = nlm_fractal((h, w), rng, octaves=4, persistence=0.65) > 0.92
+    classes[holes] = nodata
+    # nodata stripe (simulate missing swath)
+    classes[:, 235:250] = nodata
+
+    path = os.path.join(outdir, "landcover_utm33.tif")
+    write_geotiff(
+        path, classes, crs, transform, nodata=nodata, dtype="uint8",
+        tags={"SEMANTICS": "piecewise_constant", "SUGGESTED_TRANSFER": "overlay_mode|overlay_weighted(fractions)|sample_nn"}
+    )
+
+
+def make_fractional_cover(outdir, rng):
+    """
+    Fractional tree cover 0..1 (float32), with nodata mask shaped like a coastline.
+    CRS: same as landcover to allow comparison.
+    """
+    crs = CRS.from_epsg(32633)
+    w, h = 512, 512
+    px = 30.0
+    transform = from_origin(500000.0, 5100000.0, px, px)
+
+    base = nlm_fractal((h, w), rng, octaves=6, persistence=0.55)
+    # produce patches with logistic contrast; keep continuous
+    frac = 1.0 / (1.0 + np.exp(-8.0 * (base - 0.5)))
+    frac = frac.astype(np.float32)
+
+    # coastline-ish nodata mask: half-plane + noisy boundary
+    yy, xx = np.mgrid[0:h, 0:w]
+    boundary = (0.55 * w + 25 * (smooth(rng.random((h, w), dtype=np.float32), 6.0) - 0.5)).astype(np.float32)
+    mask = xx > boundary  # "ocean" nodata
+    nodata = np.float32(-9999.0)
+    frac = frac.copy()
+    frac[mask] = nodata
+
+    path = os.path.join(outdir, "frac_treecover_utm33.tif")
+    write_geotiff(
+        path, frac, crs, transform, nodata=nodata, dtype="float32",
+        tags={"SEMANTICS": "fraction_cover", "SUGGESTED_TRANSFER": "overlay_weighted(mean)|histogram(numeric)|sample_interp(careful)"}
+    )
+
+
+def make_popcount_mass_in_cell(outdir, rng):
+    """
+    Extensive count raster: per-pixel totals, skewed heavy-tailed distribution.
+    Includes a nodata polygon.
+    CRS: Web Mercator (EPSG:3857) around Nairobi-ish (just for variety).
+    """
+    crs = CRS.from_epsg(3857)
+    w, h = 600, 450
+    px = 250.0  # 250 m
+    # Upper-left: pick somewhere plausible in meters in 3857 (around East Africa region)
+    # (This is synthetic; location just needs to be on Earth-ish.)
+    transform = from_origin(4100000.0, -110000.0, px, px)
+
+    field = nlm_fractal((h, w), rng, octaves=6, persistence=0.6)
+    # Make a "city" hotspot + corridors
+    yy, xx = np.mgrid[0:h, 0:w]
+    cx, cy = int(0.62 * w), int(0.42 * h)
+    r2 = (xx - cx) ** 2 + (yy - cy) ** 2
+    hotspot = np.exp(-r2 / (2 * (0.12 * min(h, w)) ** 2)).astype(np.float32)
+    corridor = np.exp(-((yy - 0.55 * h) ** 2) / (2 * (0.07 * h) ** 2)).astype(np.float32)
+
+    intensity = np.clip(0.55 * field + 0.9 * hotspot + 0.3 * corridor, 0, 1)
+    # Heavy-tailed counts: lognormal-ish
+    counts = (np.exp(4.0 * intensity) - 1.0) * 3.0
+    counts = np.rint(counts).astype(np.int32)
+
+    nodata = -2147483648
+    # nodata polygon: an arbitrary rotated rectangle mask
+    x0, y0 = 0.2 * w, 0.2 * h
+    x1, y1 = 0.55 * w, 0.35 * h
+    theta = math.radians(25)
+    X = (xx - x0) * math.cos(theta) + (yy - y0) * math.sin(theta)
+    Y = -(xx - x0) * math.sin(theta) + (yy - y0) * math.cos(theta)
+    poly_mask = (X > 0) & (X < (x1 - x0)) & (Y > 0) & (Y < (y1 - y0))
+    counts = counts.copy()
+    counts[poly_mask] = nodata
+
+    path = os.path.join(outdir, "popcount_webmerc.tif")
+    write_geotiff(
+        path, counts, crs, transform, nodata=nodata, dtype="int32",
+        tags={"SEMANTICS": "count_total", "SUGGESTED_TRANSFER": "mass_preserve(sum)"}
+    )
+
+
+def make_temp_cell_average_geographic(outdir, rng):
+    """
+    Continuous raster intended to be treated as cell-average (block support),
+    stored in geographic CRS to exercise area-model choices.
+    CRS: WGS84 (EPSG:4326) around SE Australia.
+    """
+    crs = CRS.from_epsg(4326)
+    w, h = 720, 360
+    # 0.01 degree pixels (~1.1 km lat, variable lon)
+    res = 0.01
+    # Upper-left lon/lat
+    transform = from_origin(144.0, -36.0, res, res)  # around Melbourne-ish
+
+    base = nlm_fractal((h, w), rng, octaves=6, persistence=0.55)
+    grad = np.linspace(0, 1, w, dtype=np.float32)[None, :]
+    temp = 12.0 + 10.0 * (0.65 * base + 0.35 * grad)  # ~12..22
+    temp = temp.astype(np.float32)
+
+    nodata = np.float32(-9999.0)
+    temp = temp.copy()
+    # nodata band near one edge + scattered missing pixels
+    temp[:25, :] = nodata
+    scatter = rng.random((h, w), dtype=np.float32) > 0.995
+    temp[scatter] = nodata
+
+    path = os.path.join(outdir, "temp_mean_wgs84.tif")
+    write_geotiff(
+        path, temp, crs, transform, nodata=nodata, dtype="float32",
+        tags={"SEMANTICS": "cell_average", "SUGGESTED_TRANSFER": "overlay_weighted(mean, area-model matters)"}
+    )
+
+
+def make_zone_ids_laea(outdir, rng):
+    """
+    Categorical zone IDs in an equal-area CRS to test overlay behavior.
+    CRS: Europe LAEA (EPSG:3035).
+    """
+    crs = CRS.from_epsg(3035)
+    w, h = 500, 500
+    px = 1000.0  # 1 km
+    transform = from_origin(4000000.0, 3200000.0, px, px)
+
+    yy, xx = np.mgrid[0:h, 0:w]
+    # Build a few big zones as Voronoi-like regions from random seeds
+    n_seeds = 8
+    seeds = np.stack([rng.integers(0, w, size=n_seeds), rng.integers(0, h, size=n_seeds)], axis=1)
+    dmin = None
+    idx = None
+    for i, (sx, sy) in enumerate(seeds):
+        d = (xx - sx) ** 2 + (yy - sy) ** 2
+        if dmin is None:
+            dmin = d
+            idx = np.full((h, w), i, dtype=np.int32)
+        else:
+            mask = d < dmin
+            idx[mask] = i
+            dmin[mask] = d[mask]
+
+    zones = (idx + 1).astype(np.uint16)  # 1..n
+    nodata = 0
+    # Add "islands" of nodata and tiny zones
+    islands = nlm_fractal((h, w), rng, octaves=4, persistence=0.65) > 0.94
+    zones[islands] = nodata
+    # Tiny zone patches (simulate slivers)
+    slivers = nlm_fractal((h, w), rng, octaves=5, persistence=0.5) > 0.985
+    zones[slivers] = (n_seeds + 1)
+
+    path = os.path.join(outdir, "zone_ids_laea.tif")
+    write_geotiff(
+        path, zones, crs, transform, nodata=nodata, dtype="uint16",
+        tags={"SEMANTICS": "piecewise_constant", "SUGGESTED_TRANSFER": "overlay_mode|overlay_weighted(fractions)"}
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outdir", default="sample_rasters", help="Output directory")
+    ap.add_argument("--seed", type=int, default=42, help="Random seed")
+    args = ap.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+
+    make_landcover_piecewise_constant(args.outdir, rng)
+    make_fractional_cover(args.outdir, rng)
+    make_popcount_mass_in_cell(args.outdir, rng)
+    make_temp_cell_average_geographic(args.outdir, rng)
+    make_zone_ids_laea(args.outdir, rng)
+
+    print(f"Wrote rasters to: {args.outdir}")
+    print(f"scipy available: {HAVE_SCIPY} (gaussian smoothing {'enabled' if HAVE_SCIPY else 'using box blur fallback'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/raster2dggs/cli_factory.py
+++ b/raster2dggs/cli_factory.py
@@ -35,7 +35,7 @@ SPECS: List[DGGS_Spec] = [
         3,
     ),
     DGGS_Spec("s2", "S2", const.MIN_S2, const.MAX_S2, 8),
-    DGGS_Spec("a5", "A5", const.MIN_A5, const.MAX_A5, 8),
+    DGGS_Spec("a5", "A5", const.MIN_A5, const.MAX_A5, 8), # TODO slow, replace with a5_fast
     DGGS_Spec("isea4r", "ISEA4R", const.MIN_ISEA4R, const.MAX_ISEA4R, 8),
     DGGS_Spec("isea9r", "ISEA9R", const.MIN_ISEA9R, const.MAX_ISEA9R, 5),
     DGGS_Spec("isea3h", "ISEA3H", const.MIN_ISEA3H, const.MAX_ISEA3H, 10),
@@ -51,7 +51,7 @@ SPECS: List[DGGS_Spec] = [
     DGGS_Spec("rtea7h", "RTEA7H", const.MIN_RTEA7H, const.MAX_RTEA7H, 6),
     # DGGS_Spec("rtea7h_z7", "RTEA7H_Z7", const.MIN_RTEA7H_Z7, const.MAX_RTEA7H_Z7, 6),
     DGGS_Spec("healpix", "HEALPix", const.MIN_HEALPIX, const.MAX_HEALPIX, 5),
-    # DGGS_Spec("rhealpix", "rHEALPix", const.MIN_RHEALPIX, const.MAX_RHEALPIX, 5), # Prefer rhp
+    DGGS_Spec("rhealpix", "rHEALPix", const.MIN_RHEALPIX, const.MAX_RHEALPIX, 5), # Prefer rhp
 ]
 # NB use 5 for IS/VEA9R, and 10 for IS/VEA3H, and 8 for GNOSIS --- corresponds to ~64K sub-zones
 
@@ -70,6 +70,8 @@ def run_index(
     resolution: int,
     parent_res: int,
     band,
+    nodata_policy: str,
+    emit_nodata_value: Optional[float],
     upscale: int,
     compression: str,
     threads: int,
@@ -110,6 +112,8 @@ def run_index(
         parent_res,
         warp_args,
         band,
+        nodata_policy,
+        emit_nodata_value,
         **kwargs,
     )
 
@@ -148,6 +152,31 @@ def make_command(spec: DGGS_Spec):
         required=False,
         multiple=True,
         help="Band(s) to include in the output. Can specify multiple, e.g. `-b 1 -b 2 -b 4` for bands 1, 2, and 4 (all unspecified bands are ignored). If unused, all bands are included in the output (this is the default behaviour). Bands can be specified as numeric indices (1-based indexing) or string band labels (if present in the input), e.g. -b B02 -b B07 -b B12.",
+    )
+    @click.option(
+        "--nodata_policy",
+        type=click.Choice(const.NODATA_POLICY_OPTIONS, case_sensitive=False),
+        default=const.DEFAULTS["nodata_policy"],
+        show_default=True,
+        help=(
+            "'skip' omits nodata cells from output (default). "
+            "'emit' includes them, writing the source raster nodata value (or --emit_nodata_value if set). "
+            "Note: non-NaN emitted values participate in cell aggregation (see -a/--aggfunc); "
+            "if this is undesired, ensure your source nodata is NaN or override with --emit_nodata_value."
+        ),
+    )
+    @click.option(
+        "--emit_nodata_value",
+        default=None,
+        type=float,
+        metavar="NUMBER",
+        help=(
+            "Override the value written for nodata cells when --nodata_policy=emit. "
+            "If omitted, the source raster nodata value is used (NaN if none is defined). "
+            "Pass 'nan' to explicitly emit NaN. "
+            "Coerced to the output dtype. "
+            "Note: non-NaN values participate in cell aggregation (see -a/--aggfunc)."
+        ),
     )
     @click.option(
         "-u",
@@ -222,6 +251,8 @@ def make_command(spec: DGGS_Spec):
         resolution,
         parent_res,
         band,
+        nodata_policy,
+        emit_nodata_value,
         upscale,
         compression,
         threads,
@@ -246,6 +277,8 @@ def make_command(spec: DGGS_Spec):
             resolution,
             parent_res,
             band,
+            nodata_policy,
+            emit_nodata_value,
             upscale,
             compression,
             threads,

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -305,6 +305,8 @@ def initial_index(
     parent_res: Union[None, int],
     warp_args: dict,
     bands: Optional[Sequence[Union[int, str]]] = None,
+    nodata_policy: str = "skip",
+    emit_nodata_value: Optional[Union[int, float]] = None,
     **kwargs,
 ) -> Path:
     """
@@ -402,7 +404,7 @@ def initial_index(
                     da: xr.Dataset = rioxarray.open_rasterio(
                         vrt,
                         lock=dask.utils.SerializableLock(),
-                        masked=True,
+                        masked=False,
                         default_name=const.DEFAULT_NAME,
                     ).chunk(**{"y": "auto", "x": "auto"})
 
@@ -435,6 +437,8 @@ def initial_index(
                             parent_res,
                             vrt.nodata,
                             band_labels=selected_labels,
+                            nodata_policy=nodata_policy,
+                            emit_nodata_value=emit_nodata_value,
                         )
 
                         partition_col = indexer.partition_col(parent_res)

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -92,6 +92,7 @@ DEFAULTS = {
     "resampling": "average",
     "geo": "none",
     "tempdir": tempfile.tempdir,
+    "nodata_policy": "skip",
 }
 
 
@@ -141,3 +142,5 @@ AGGFUNC_OPTIONS = [
 ]
 
 GEOM_TYPES = ["point", "polygon", "none"]
+
+NODATA_POLICY_OPTIONS = ["skip", "emit"]

--- a/raster2dggs/indexers/a5rasterindexer.py
+++ b/raster2dggs/indexers/a5rasterindexer.py
@@ -2,17 +2,9 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import a5 as a5py
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -22,48 +14,20 @@ class A5RasterIndexer(RasterIndexer):
     Provides integration for the A5 DGGS.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        resolution: int,
-        parent_res: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to A5.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
+    def _index_window(self, wide, resolution: int, parent_res: int):
         cells = [
             a5py.lonlat_to_cell((lon, lat), resolution)
-            for lon, lat in zip(subset["x"], subset["y"])
+            for lon, lat in zip(wide["x"], wide["y"])
         ]  # NB a5py.lonlat_to_cell is quite slow
-        # Secondary (parent) A5 index, used later for partitioning
         a5_parent = [a5py.cell_to_parent(cell, parent_res) for cell in cells]
-        subset = subset.drop(columns=["x", "y"])
-        index_col = self.index_col(resolution)
-        subset[index_col] = pd.Series(map(a5py.u64_to_hex, cells), index=subset.index)
-        partition_col = self.partition_col(parent_res)
-        subset[partition_col] = pd.Series(
-            map(a5py.u64_to_hex, a5_parent), index=subset.index
+        wide = wide.drop(columns=["x", "y"])
+        wide[self.index_col(resolution)] = pd.Series(
+            map(a5py.u64_to_hex, cells), index=wide.index
         )
-        # Renaming columns to actual band labels
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        subset = subset.rename(columns=columns)
-        return pa.Table.from_pandas(subset)
+        wide[self.partition_col(parent_res)] = pd.Series(
+            map(a5py.u64_to_hex, a5_parent), index=wide.index
+        )
+        return wide
 
     @staticmethod
     def cell_to_children_size(cell: int, desired_resolution: int) -> int:

--- a/raster2dggs/indexers/dggalrasterindexer.py
+++ b/raster2dggs/indexers/dggalrasterindexer.py
@@ -3,18 +3,12 @@
 """
 
 from abc import abstractmethod
-from functools import reduce, lru_cache
-from numbers import Number
-from typing import List, Tuple
+from functools import lru_cache
+from typing import List
 
 import dggal
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -62,52 +56,22 @@ class DGGALRasterIndexer(RasterIndexer):
             parent = self._get_parent(int(parent))
         return parent
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        resolution: int,
-        parent_res: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to a DGGRS.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # Primary DGGSRS index
+    def _index_window(self, wide, resolution: int, parent_res: int):
         cells = [
             self.dggrs.getZoneFromWGS84Centroid(resolution, dggal.GeoPoint(lon, lat))
-            for lon, lat in zip(subset["y"], subset["x"])
+            for lon, lat in zip(wide["y"], wide["x"])
         ]  # Vectorised
         dggrs_parent = [
             self._get_ancestor(zone, resolution - parent_res) for zone in cells
         ]
-        subset = subset.drop(columns=["x", "y"])
-        index_col = self.index_col(resolution)
-        subset[index_col] = pd.Series(
-            map(self.dggrs.getZoneTextID, cells), index=subset.index
+        wide = wide.drop(columns=["x", "y"])
+        wide[self.index_col(resolution)] = pd.Series(
+            map(self.dggrs.getZoneTextID, cells), index=wide.index
         )
-        partition_col = self.partition_col(parent_res)
-        subset[partition_col] = pd.Series(
-            map(self.dggrs.getZoneTextID, dggrs_parent), index=subset.index
+        wide[self.partition_col(parent_res)] = pd.Series(
+            map(self.dggrs.getZoneTextID, dggrs_parent), index=wide.index
         )
-        # Rename bands
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        subset = subset.rename(columns=columns)
-        return pa.Table.from_pandas(subset)
+        return wide
 
     def cell_to_children_size(self, cell: str, desired_resolution: int) -> int:
         """

--- a/raster2dggs/indexers/geohashrasterindexer.py
+++ b/raster2dggs/indexers/geohashrasterindexer.py
@@ -2,17 +2,9 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import geohash as gh
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -22,47 +14,17 @@ class GeohashRasterIndexer(RasterIndexer):
     Provides integration for the Geohash geocode system.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        precision: int,
-        parent_precision: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to Geohash.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # Primary Geohash index
+    def _index_window(self, wide, resolution: int, parent_res: int):
         geohash = [
-            gh.encode(lat, lon, precision=precision)
-            for lat, lon in zip(subset["y"], subset["x"])
-        ]  # Vectorised
-        # Secondary (parent) Geohash index, used later for partitioning
-        geohash_parent = [gh[:parent_precision] for gh in geohash]
-        subset = subset.drop(columns=["x", "y"])
-        index_col = self.index_col(precision)
-        subset[index_col] = pd.Series(geohash, index=subset.index)
-        partition_col = self.partition_col(parent_precision)
-        subset[partition_col] = pd.Series(geohash_parent, index=subset.index)
-        # Rename bands
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        subset = subset.rename(columns=columns)
-        return pa.Table.from_pandas(subset)
+            gh.encode(lat, lon, precision=resolution)
+            for lat, lon in zip(wide["y"], wide["x"])
+        ]
+        wide = wide.drop(columns=["x", "y"])
+        wide[self.index_col(resolution)] = pd.Series(geohash, index=wide.index)
+        wide[self.partition_col(parent_res)] = pd.Series(
+            [g[:parent_res] for g in geohash], index=wide.index
+        )
+        return wide
 
     @staticmethod
     def cell_to_children_size(cell, desired_level: int) -> int:

--- a/raster2dggs/indexers/h3rasterindexer.py
+++ b/raster2dggs/indexers/h3rasterindexer.py
@@ -2,19 +2,11 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import h3pandas  # Necessary import despite lack of explicit use
 
 import h3 as h3py
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -24,41 +16,11 @@ class H3RasterIndexer(RasterIndexer):
     Provides integration for Uber's H3 DGGS.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        resolution: int,
-        parent_res: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to H3.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # Primary H3 index
-        h3index = subset.h3.geo_to_h3(resolution, lat_col="y", lng_col="x").drop(
+    def _index_window(self, wide, resolution: int, parent_res: int):
+        h3df = wide.h3.geo_to_h3(resolution, lat_col="y", lng_col="x").drop(
             columns=["x", "y"]
         )
-        # Secondary (parent) H3 index, used later for partitioning
-        h3index = h3index.h3.h3_to_parent(parent_res).reset_index()
-        # Renaming columns to actual band labels
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        h3index = h3index.rename(columns=columns)
-        return pa.Table.from_pandas(h3index)
+        return h3df.h3.h3_to_parent(parent_res).reset_index()
 
     @staticmethod
     def cell_to_children_size(cell, desired_resolution: int) -> int:

--- a/raster2dggs/indexers/maidenheadrasterindexer.py
+++ b/raster2dggs/indexers/maidenheadrasterindexer.py
@@ -2,17 +2,9 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import maidenhead as mh
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -22,49 +14,18 @@ class MaidenheadRasterIndexer(RasterIndexer):
     Provides integration for Maidenhead Locator System geocodes.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        precision: int,
-        parent_precision: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to Maidenhead.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # Primary Maidenhead index
+    def _index_window(self, wide, resolution: int, parent_res: int):
         maidenhead = [
-            mh.to_maiden(lat, lon, precision)
-            for lat, lon in zip(subset["y"], subset["x"])
-        ]  # Vectorised
-        # Secondary (parent) Maidenhead index, used later for partitioning
-        maidenhead_parent = [
-            self.cell_to_parent(mh, parent_precision) for mh in maidenhead
+            mh.to_maiden(lat, lon, resolution)
+            for lat, lon in zip(wide["y"], wide["x"])
         ]
-        subset = subset.drop(columns=["x", "y"])
-        index_col = self.index_col(precision)
-        subset[index_col] = pd.Series(maidenhead, index=subset.index)
-        partition_col = self.partition_col(parent_precision)
-        subset[partition_col] = pd.Series(maidenhead_parent, index=subset.index)
-        # Rename bands
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        subset = subset.rename(columns=columns)
-        return pa.Table.from_pandas(subset)
+        maidenhead_parent = [self.cell_to_parent(m, parent_res) for m in maidenhead]
+        wide = wide.drop(columns=["x", "y"])
+        wide[self.index_col(resolution)] = pd.Series(maidenhead, index=wide.index)
+        wide[self.partition_col(parent_res)] = pd.Series(
+            maidenhead_parent, index=wide.index
+        )
+        return wide
 
     @staticmethod
     def cell_to_children_size(cell, desired_level: int) -> int:

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -3,7 +3,7 @@
 """
 
 from numbers import Number
-from typing import Callable, Tuple, Union
+from typing import Callable, Tuple, Union, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -12,6 +12,24 @@ import numpy as np
 
 from .. import constants as const
 from ..interfaces import IRasterIndexer
+
+
+def _is_nan(v) -> bool:
+    try:
+        return bool(np.isnan(v))
+    except Exception:
+        return False
+
+
+def _mask_is_nodata(series: pd.Series, nodata) -> pd.Series:
+    """Return boolean mask where True means the pixel is nodata."""
+    if nodata is None:
+        return pd.Series(False, index=series.index)
+    if _is_nan(nodata):
+        return series.isna()
+    else:
+        # Sentinel nodata: also treat unexpected NaNs as nodata
+        return series.isna() | (series == nodata)
 
 
 class RasterIndexer(IRasterIndexer):
@@ -75,9 +93,47 @@ class RasterIndexer(IRasterIndexer):
         parent_res: int,
         nodata: Number = np.nan,
         band_labels: Tuple[str] = None,
+        nodata_policy: str = "skip",
+        emit_nodata_value: Optional[Number] = None,
     ) -> pa.Table:
+        sdf: pd.DataFrame = (
+            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
+        )
+        nodata_mask = _mask_is_nodata(sdf[const.DEFAULT_NAME], nodata)
+        if nodata_policy.lower() == "skip":
+            sdf = sdf[~nodata_mask].copy()
+        elif nodata_policy.lower() == "emit":
+            sdf = sdf.copy()
+            fill_value = emit_nodata_value if emit_nodata_value is not None else nodata
+            if pd.isna(fill_value):
+                if pd.api.types.is_integer_dtype(sdf[const.DEFAULT_NAME]):
+                    sdf[const.DEFAULT_NAME] = sdf[const.DEFAULT_NAME].astype(float)
+                sdf.loc[nodata_mask, const.DEFAULT_NAME] = np.nan
+            else:
+                dtype = sdf[const.DEFAULT_NAME].dtype
+                sdf.loc[nodata_mask, const.DEFAULT_NAME] = dtype.type(fill_value)
+        else:
+            raise ValueError(f"Unknown nodata policy: {nodata_policy}")
+        wide = pd.pivot_table(
+            sdf, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
+        ).reset_index()
+        wide = self._index_window(wide, resolution, parent_res)
+        bands = sorted(sdf["band"].unique())
+        if band_labels is None:
+            band_labels = tuple(str(b) for b in bands)
+        wide = wide.rename(columns=dict(zip(bands, band_labels)))
+        return pa.Table.from_pandas(wide, preserve_index=False)
+
+    def _index_window(
+        self,
+        wide: pd.DataFrame,
+        resolution: int,
+        parent_res: int,
+    ) -> pd.DataFrame:
         """
-        Needs to be implemented by child class
+        Receives a pivoted wide DataFrame with x/y columns and band value columns.
+        Must return it with x/y dropped and DGGS cell-index + parent-partition columns added.
+        Needs to be implemented by child class.
         """
         raise NotImplementedError()
 
@@ -154,7 +210,7 @@ class RasterIndexer(IRasterIndexer):
                     continue
                 expected_count = self.expected_count(parent, resolution)
                 if len(group) == expected_count and all(
-                    group[band_cols].nunique() == 1
+                    group[band_cols].nunique(dropna=False) == 1
                 ):
                     compact_row = group.iloc[0]
                     compact_row.name = parent  # Rename the index to the parent cell

--- a/raster2dggs/indexers/rhprasterindexer.py
+++ b/raster2dggs/indexers/rhprasterindexer.py
@@ -2,20 +2,12 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import rhppandas  # Necessary import despite lack of explicit use
 
 import rhealpixdggs.rhp_wrappers as rhpw
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
 from rhealpixdggs.dggs import WGS84_003
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -25,41 +17,11 @@ class RHPRasterIndexer(RasterIndexer):
     Provides integration for MWLR's rHEALPix DGGS.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        resolution: int,
-        parent_res: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to rHEALPix.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # Primary rHEALPix index
-        rhpindex = subset.rhp.geo_to_rhp(resolution, lat_col="y", lng_col="x").drop(
+    def _index_window(self, wide, resolution: int, parent_res: int):
+        rhpdf = wide.rhp.geo_to_rhp(resolution, lat_col="y", lng_col="x").drop(
             columns=["x", "y"]
         )
-        # Secondary (parent) rHEALPix index, used later for partitioning
-        rhpindex = rhpindex.rhp.rhp_to_parent(parent_res).reset_index()
-        # Renaming columns to actual band labels
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        rhpindex = rhpindex.rename(columns=columns)
-        return pa.Table.from_pandas(rhpindex)
+        return rhpdf.rhp.rhp_to_parent(parent_res).reset_index()
 
     @staticmethod
     def cell_to_children_size(cell, desired_resolution: int) -> int:

--- a/raster2dggs/indexers/s2rasterindexer.py
+++ b/raster2dggs/indexers/s2rasterindexer.py
@@ -2,17 +2,9 @@
 @author: ndemaio
 """
 
-from numbers import Number
-from typing import Tuple
-
 import s2sphere
 import pandas as pd
-import pyarrow as pa
-import xarray as xr
-import numpy as np
 import shapely
-
-import raster2dggs.constants as const
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
@@ -22,47 +14,19 @@ class S2RasterIndexer(RasterIndexer):
     Provides integration for Google's S2 DGGS.
     """
 
-    def index_func(
-        self,
-        sdf: xr.DataArray,
-        resolution: int,
-        parent_res: int,
-        nodata: Number = np.nan,
-        band_labels: Tuple[str] = None,
-    ) -> pa.Table:
-        """
-        Index a raster window to S2.
-        Subsequent steps are necessary to resolve issues at the boundaries of windows.
-        If windows are very small, or in strips rather than blocks, processing may be slower
-        than necessary and the recommendation is to write different windows in the source raster.
-
-        Implementation of interface function.
-        """
-        sdf: pd.DataFrame = (
-            sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
-        )
-        subset: pd.DataFrame = sdf.dropna()
-        subset = subset[subset.value != nodata]
-        subset = pd.pivot_table(
-            subset, values=const.DEFAULT_NAME, index=["x", "y"], columns=["band"]
-        ).reset_index()
-        # S2 index
+    def _index_window(self, wide, resolution: int, parent_res: int):
         cells = [
             s2sphere.CellId.from_lat_lng(s2sphere.LatLng.from_degrees(lat, lon))
-            for lat, lon in zip(subset["y"], subset["x"])
+            for lat, lon in zip(wide["y"], wide["x"])
         ]
-        s2 = [cell.parent(resolution).to_token() for cell in cells]
-        s2_parent = [cell.parent(parent_res).to_token() for cell in cells]
-        subset = subset.drop(columns=["x", "y"])
-        index_col = self.index_col(resolution)
-        subset[index_col] = pd.Series(s2, index=subset.index)
-        partition_col = self.partition_col(parent_res)
-        subset[partition_col] = pd.Series(s2_parent, index=subset.index)
-        # Renaming columns to actual band labels
-        bands = sdf["band"].unique()
-        columns = dict(zip(bands, band_labels))
-        subset = subset.rename(columns=columns)
-        return pa.Table.from_pandas(subset)
+        wide = wide.drop(columns=["x", "y"])
+        wide[self.index_col(resolution)] = pd.Series(
+            [c.parent(resolution).to_token() for c in cells], index=wide.index
+        )
+        wide[self.partition_col(parent_res)] = pd.Series(
+            [c.parent(parent_res).to_token() for c in cells], index=wide.index
+        )
+        return wide
 
     @staticmethod
     def cell_to_children_size(cell, desired_resolution: int) -> int:

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -3,7 +3,7 @@
 """
 
 from numbers import Number
-from typing import Callable, Tuple, Union
+from typing import Callable, Tuple, Union, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -76,6 +76,8 @@ class IRasterIndexer:
         parent_res: int,
         nodata: Number = np.nan,
         band_labels: Tuple[str] = None,
+        nodata_policy: str = "skip",
+        emit_nodata_value: Optional[Number] = None,
     ) -> pa.Table:
         """
         Function for primary indexation.

--- a/tests/classes/test_nodata.py
+++ b/tests/classes/test_nodata.py
@@ -1,0 +1,124 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+import rasterio
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
+
+from click.testing import CliRunner
+
+from classes.base import TestRunthrough
+from data.datapaths import TEST_OUTPUT_PATH
+from raster2dggs.cli import cli
+from raster2dggs.indexers.rasterindexer import _mask_is_nodata
+
+
+NODATA_SENTINEL = -9999.0
+# 10x10 pixel Float32 raster in EPSG:4326; top-left pixel is nodata
+RASTER_BOUNDS = (174.0, -41.1, 174.1, -41.0)  # (left, bottom, right, top)
+RASTER_SIZE = 10
+H3_RES = 7  # fine enough that each pixel maps to its own cell
+
+
+def _make_test_raster(path: str, nodata: float = NODATA_SENTINEL) -> None:
+    data = np.full((1, RASTER_SIZE, RASTER_SIZE), 42.0, dtype=np.float32)
+    data[0, 0, 0] = nodata  # one isolated nodata pixel
+    transform = from_bounds(*RASTER_BOUNDS, RASTER_SIZE, RASTER_SIZE)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=RASTER_SIZE,
+        width=RASTER_SIZE,
+        count=1,
+        dtype="float32",
+        crs=CRS.from_epsg(4326),
+        transform=transform,
+        nodata=nodata,
+    ) as dst:
+        dst.write(data)
+
+
+def _read_output(output_dir: Path) -> pd.DataFrame:
+    return pq.read_table(str(output_dir)).to_pandas()
+
+
+class TestMaskIsNodata(TestCase):
+    def test_nodata_none_returns_all_false(self):
+        s = pd.Series([1.0, 2.0, np.nan])
+        self.assertFalse(_mask_is_nodata(s, nodata=None).any())
+
+    def test_nodata_nan_masks_nans_only(self):
+        s = pd.Series([1.0, np.nan, 3.0])
+        result = _mask_is_nodata(s, nodata=np.nan)
+        self.assertEqual(result.tolist(), [False, True, False])
+
+    def test_nodata_nan_does_not_mask_valid(self):
+        s = pd.Series([1.0, 2.0, 3.0])
+        self.assertFalse(_mask_is_nodata(s, nodata=np.nan).any())
+
+    def test_nodata_sentinel_masks_matching_values(self):
+        s = pd.Series([1.0, NODATA_SENTINEL, 3.0])
+        result = _mask_is_nodata(s, nodata=NODATA_SENTINEL)
+        self.assertEqual(result.tolist(), [False, True, False])
+
+    def test_nodata_sentinel_also_masks_nans(self):
+        s = pd.Series([1.0, NODATA_SENTINEL, np.nan])
+        result = _mask_is_nodata(s, nodata=NODATA_SENTINEL)
+        self.assertEqual(result.tolist(), [False, True, True])
+
+    def test_nodata_sentinel_does_not_mask_other_values(self):
+        s = pd.Series([0.0, 1.0, 2.0])
+        self.assertFalse(_mask_is_nodata(s, nodata=NODATA_SENTINEL).any())
+
+
+class TestNodataPolicy(TestRunthrough):
+    def setUp(self):
+        super().setUp()
+        self._raster = tempfile.NamedTemporaryFile(suffix=".tiff", delete=False)
+        _make_test_raster(self._raster.name)
+
+    def tearDown(self):
+        super().tearDown()
+        Path(self._raster.name).unlink(missing_ok=True)
+
+    def _run(self, *extra_args):
+        if TEST_OUTPUT_PATH.exists():
+            self.clearOutFolder(TEST_OUTPUT_PATH)
+        TEST_OUTPUT_PATH.mkdir(exist_ok=True)
+        runner = CliRunner()
+        args = [
+            "h3",
+            self._raster.name,
+            str(TEST_OUTPUT_PATH),
+            "-r", str(H3_RES),
+        ] + list(extra_args)
+        result = runner.invoke(cli, args, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        return _read_output(TEST_OUTPUT_PATH)
+
+    def test_skip_excludes_nodata_cells(self):
+        df = self._run("--nodata_policy", "skip")
+        self.assertFalse((df["band_1"] == NODATA_SENTINEL).any(),
+                         "skip policy should produce no nodata-sentinel values")
+        self.assertFalse(df["band_1"].isna().any(),
+                         "skip policy should produce no NaN values")
+
+    def test_emit_with_explicit_value_lowers_cell_value(self):
+        # All valid pixels have value 42. The nodata pixel is replaced with 0,
+        # so any H3 cell containing it will have a mean < 42 (or exactly 0 if isolated).
+        df_skip = self._run("--nodata_policy", "skip")
+        skip_min = df_skip["band_1"].min()
+        df_emit = self._run("--nodata_policy", "emit", "--emit_nodata_value", "0")
+        self.assertLess(df_emit["band_1"].min(), skip_min,
+                        "replacing nodata with 0 should pull at least one cell's mean below 42")
+
+    def test_emit_without_explicit_value_includes_nodata_cells(self):
+        df_skip = self._run("--nodata_policy", "skip")
+        df_emit = self._run("--nodata_policy", "emit")
+        self.assertGreaterEqual(len(df_emit), len(df_skip),
+                                "emit policy should produce at least as many rows as skip")

--- a/tests/data/datapaths.py
+++ b/tests/data/datapaths.py
@@ -4,5 +4,7 @@
 
 from pathlib import Path
 
-TEST_FILE_PATH = "./data/se-island.tiff"
-TEST_OUTPUT_PATH = Path("./data/output/")
+_DATA_DIR = Path(__file__).parent
+
+TEST_FILE_PATH = str(_DATA_DIR / "se-island.tiff")
+TEST_OUTPUT_PATH = _DATA_DIR / "output"

--- a/tests/test_raster2dggs.py
+++ b/tests/test_raster2dggs.py
@@ -4,8 +4,12 @@
 
 import sys
 import unittest
+from pathlib import Path
 
 if __name__ == "__main__":
-    testSuite = unittest.defaultTestLoader.discover(start_dir=".", top_level_dir=".")
+    tests_dir = str(Path(__file__).parent)
+    if tests_dir not in sys.path:
+        sys.path.insert(0, tests_dir)
+    testSuite = unittest.defaultTestLoader.discover(start_dir=tests_dir, top_level_dir=tests_dir)
     testRunner = unittest.TextTestRunner(stream=sys.stdout, verbosity=2, buffer=False)
     testRunner.run(testSuite)


### PR DESCRIPTION
Ref. #2 

- "Null data is currently omitted as early as possible" — preserved as the default (`--nodata_policy skip`), so existing users see no behaviour change.
- "The tool could have an optional value to be used to fill nodata cells" — `--nodata_policy emit --emit_nodata_value 0` does exactly this: nodata pixels are filled with 0 before aggregation.
- The DEM/water example — `raster2dggs h3 dem.tiff output/ -r 7 --nodata_policy emit --emit_nodata_value 0` would give water pixels the value 0, so cells at the margin of water areas aggregate over both land elevation and 0, rather than silently dropping the water pixels from the mean.

The implementation goes slightly beyond the brief (you can also emit NaN, or emit the source nodata sentinel without an explicit override). **The default behaviour is unchanged.**

## Addenda...

- There is also some refactoring of common indexing code which also related to null handling. All tests pass.
- I have included a script for making some synthetic sample raster data; useful for testing different data types, null patterns, etc.