### PR TITLE
Unlock piecewise_constant + sample_nn + value

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -665,7 +665,7 @@ def initial_index(
 
                 def process_nn(window):
                     """
-                    Cell-driven stage-1 for sample_nn / point_sample_field.
+                    Cell-driven stage-1 for sample_nn.
 
                     Enumerates every DGGS cell whose centre falls within the
                     window's geographic bbox, converts each centre to the

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -202,6 +202,7 @@ IMPLEMENTED: set = {
     ("point_center_strict", "assign_centers", "list"),
     ("point_center_strict", "assign_centers", "histogram"),
     ("point_sample_field", "sample_nn", "value"),
+    ("piecewise_constant", "sample_nn", "value"),
 }
 
 

--- a/tests/classes/test_output_schema.py
+++ b/tests/classes/test_output_schema.py
@@ -414,26 +414,18 @@ class TestOutListValidation(TestRunthrough):
             "point_sample_field + sample_interp is valid but not yet implemented",
         )
 
-    def test_sample_nn_runs(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "h3",
-                self._raster,
-                str(TEST_OUTPUT_PATH),
-                "-r",
-                str(_COARSE_RES),
-                "--semantics",
-                "point_sample_field",
-                "--transfer",
-                "sample_nn",
-                "--out",
-                "value",
-            ],
+    def test_sample_nn_point_sample_field_runs(self):
+        self.invoke_cli(
+            "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
+            "--semantics", "point_sample_field",
+            "--transfer", "sample_nn",
+            "--out", "value",
         )
-        self.assertEqual(
-            result.exit_code,
-            0,
-            f"point_sample_field + sample_nn should succeed: {result.output}",
+
+    def test_sample_nn_piecewise_constant_runs(self):
+        self.invoke_cli(
+            "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
+            "--semantics", "piecewise_constant",
+            "--transfer", "sample_nn",
+            "--out", "value",
         )


### PR DESCRIPTION
Adds the combination to IMPLEMENTED — the underlying sample_nn path (enumerate DGGS cells in bbox, look up nearest pixel value) is already fully generic and works correctly for categorical rasters. Updates the stale process_nn docstring and adds two targeted tests.

Part of #17 / #50