### PR TITLE
Point sample field interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ Options:
   --transfer [assign_centers|sample|overlay_weighted|overlay_mode|mass_preserve]
                                   How values are mapped from raster pixels to
                                   DGGS cells.  [default: assign_centers]
-  --interp [nn]                   Interpolation method used with --transfer
+  --interp [nn|bilinear|bicubic|lanczos]
+                                  Interpolation method used with --transfer
                                   sample. Ignored for other transfer
                                   operators.  [default: nn]
   --out [value|fractions|histogram|list]
@@ -193,6 +194,7 @@ Options:
                                   allows you to control where this data will
                                   be written.
   --version                       Show the version and exit.
+  --help                          Show this message and exit.
 ```
 
 ## Raster semantics and transfer operators
@@ -262,8 +264,9 @@ Legend: **✓** appropriate/common · **△** possible (with caveats) · **✗**
 | `point_center_strict` | `assign_centers` | `value` | Single `--agg` → scalar; multiple `--agg` (e.g. `min,max`) → struct per band. |
 | `point_center_strict` | `assign_centers` | `list` | Sorted list of all contributing pixel values per cell. `--agg` is ignored. |
 | `point_center_strict` | `assign_centers` | `histogram` | Value-count struct per cell. `--agg` is ignored. |
-| `point_sample_field` | `sample` | `value` | Nearest-neighbour sample at each DGGS cell centre (`--interp nn`). `--agg` is ignored. Supports `--compact`. |
-| `piecewise_constant` | `sample` | `value` | Nearest-neighbour sample at each DGGS cell centre (`--interp nn`). Suitable for categorical rasters (landcover, zone IDs, soil class). `--agg` is ignored. Supports `--compact`. |
+| `point_sample_field` | `sample` (`--interp nn`) | `value` | Nearest-neighbour sample at each DGGS cell centre. `--agg` is ignored. Supports `--compact`. |
+| `piecewise_constant` | `sample` (`--interp nn`) | `value` | Nearest-neighbour sample at each DGGS cell centre. Suitable for categorical rasters (landcover, zone IDs, soil class). `--agg` is ignored. Supports `--compact`. |
+| `point_sample_field` | `sample` (`--interp bilinear`) | `value` | Bilinear interpolation at each DGGS cell centre. `--agg` is ignored. Supports `--compact`. |
 
 All other valid combinations will raise a `NotImplementedError` with a descriptive message until they are added.
 
@@ -505,7 +508,7 @@ pytest -k h3                        # all tests whose ID contains "h3"
 pytest -k "h3 or rhp"
 pytest -k "sample and rhp"
 pytest tests/classes/test_sample_nn.py          # sample transfer smoke tests
-pytest "tests/classes/test_cli_integration.py::TestAllDGGS::test_command[h3-polygon-co]"  # exact parametrized case
+pytest "tests/classes/test_cli_integration.py::TestAllDGGS::test_command[h3-polygon-co]"  # exact parametrised case
 ```
 
 Test data are included at `tests/data/`.
@@ -587,6 +590,11 @@ raster2dggs h3 --resolution 7 --out histogram -d 0 input.tif ./output
 Nearest-neighbour sampling for a continuous field (e.g. DEM, temperature grid):
 ```bash
 raster2dggs h3 --resolution 9 --semantics point_sample_field --transfer sample input.tif ./output
+```
+
+Bilinear sampling for a continuous field:
+```bash
+raster2dggs h3 --resolution 9 --semantics point_sample_field --transfer sample --interp bilinear input.tif ./output
 ```
 
 Nearest-neighbour sampling for a categorical raster (e.g. landcover):

--- a/README.md
+++ b/README.md
@@ -153,18 +153,22 @@ Options:
                                   cores, minus one.
   -a, --agg AGGFUNC[,AGGFUNC...]  Aggregation function(s) applied when
                                   multiple raster pixels map to the same DGGS
-                                  cell. Options: count, mean, sum, prod, std,
-                                  var, min, max, median, mode, majority,
-                                  nunique, range. Comma-separate multiple
-                                  names (e.g. min,max) to produce a struct
-                                  column per band.  [default: mean]
+                                  cell (only relevant for --transfer
+                                  assign_centers). Options: count, mean, sum,
+                                  prod, std, var, min, max, median, mode,
+                                  majority, nunique, range. Comma-separate
+                                  multiple names (e.g. min,max) to produce a
+                                  struct column per band.  [default: mean]
   --semantics [point_center_strict|point_sample_field|cell_average|piecewise_constant|fraction_cover|count_total|density|event_indicator]
                                   What a raster cell value means (determines
                                   valid transfer operators).  [default:
                                   point_center_strict]
-  --transfer [assign_centers|sample_nn|sample_interp|overlay_weighted|overlay_mode|mass_preserve]
+  --transfer [assign_centers|sample|overlay_weighted|overlay_mode|mass_preserve]
                                   How values are mapped from raster pixels to
                                   DGGS cells.  [default: assign_centers]
+  --interp [nn]                   Interpolation method used with --transfer
+                                  sample. Ignored for other transfer
+                                  operators.  [default: nn]
   --out [value|fractions|histogram|list]
                                   Output schema: scalar value, class
                                   fractions, histogram, or sorted sample list.
@@ -172,8 +176,9 @@ Options:
                                   values per cell in ascending order
                                   (deterministic); use -d/--decimals to
                                   control precision.  [default: value]
-  -d, --decimals INTEGER|none     Decimal places to round output values. Use 0
-                                  for integer output, 'none' to disable
+  -d, --decimals INTEGER|none     Decimal places to round output values. 0 =
+                                  integer; negative values round to tens (-1),
+                                  hundreds (-2), etc. Use 'none' to disable
                                   rounding.  [default: 1]
   -o, --overwrite
   -co, --compact                  Compact the cells up to the parent
@@ -188,7 +193,6 @@ Options:
                                   allows you to control where this data will
                                   be written.
   --version                       Show the version and exit.
-  --help                          Show this message and exit.
 ```
 
 ## Raster semantics and transfer operators
@@ -222,8 +226,7 @@ Support for additional semantics × transfer combinations is being added increme
 | Value | Description |
 |---|---|
 | `assign_centers` | For each raster pixel, index its **centre coordinate** to a DGGS cell. Produces sparse output (gaps) when the DGGS resolution is finer than the raster. |
-| `sample_nn` | For each DGGS cell, sample the raster at the **DGGS cell centre** using nearest-neighbour. |
-| `sample_interp` | For each DGGS cell, sample the raster at the DGGS cell centre with interpolation (e.g. bilinear). Suitable for continuous fields. |
+| `sample` | For each DGGS cell, sample the raster at the **DGGS cell centre**. Use `--interp` to choose the method (default: `nn`). |
 | `overlay_weighted` | For each DGGS cell, compute overlap-weighted outputs (means, fractions, histograms). Requires an area model. |
 | `overlay_mode` | For each DGGS cell, assign the class with the greatest overlap area. Typically paired with `--valid-coverage-threshold`. |
 | `mass_preserve` | Redistribute each raster cell total into DGGS cells proportional to overlap area. Conserves sums. |
@@ -232,13 +235,13 @@ Support for additional semantics × transfer combinations is being added increme
 
 Legend: **✓** appropriate/common · **△** possible (with caveats) · **✗** inappropriate (breaks semantics)
 
-| `--semantics` | `assign_centers` | `sample_nn` | `sample_interp` | `overlay_weighted` | `overlay_mode` | `mass_preserve` | Typical `--out` / `--agg` |
+| `--semantics` | `assign_centers` | `sample` (nn) | `sample` (bilinear+) | `overlay_weighted` | `overlay_mode` | `mass_preserve` | Typical `--out` / `--agg` |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|---|
 | `point_center_strict` | **✓** | ✗ | ✗ | ✗ | ✗ | ✗ | `value` with `--agg mean\|min\|max\|…`; `--agg min,max` for struct; `--out list\|histogram` |
 | `point_sample_field` | △ | **✓** | **✓** | △ | ✗ | ✗ | `value` |
 | `cell_average` | ✗ | △ | ✗ | **✓** | ✗ | ✗ | `value --agg mean` |
-| `piecewise_constant` | ✗ | △ | ✗ | **✓** | **✓** | ✗ | `value --agg mode` or `fractions` |
-| `fraction_cover` | ✗ | △ | △ | **✓** | ✗ | ✗ | `value --agg mean` |
+| `piecewise_constant` | ✗ | **✓** | ✗ | **✓** | **✓** | ✗ | `value --agg mode` or `fractions` |
+| `fraction_cover` | ✗ | ✗ | ✗ | **✓** | ✗ | ✗ | `value --agg mean` |
 | `count_total` | ✗ | ✗ | ✗ | △ | ✗ | **✓** | `value --agg sum` |
 | `density` | ✗ | △ | △ | **✓** | ✗ | △ | `value --agg mean` |
 | `event_indicator` | △ | △ | ✗ | △ | △ | **✓** | Presence: `fractions`; Counts: `value --agg sum` |
@@ -259,8 +262,8 @@ Legend: **✓** appropriate/common · **△** possible (with caveats) · **✗**
 | `point_center_strict` | `assign_centers` | `value` | Single `--agg` → scalar; multiple `--agg` (e.g. `min,max`) → struct per band. |
 | `point_center_strict` | `assign_centers` | `list` | Sorted list of all contributing pixel values per cell. `--agg` is ignored. |
 | `point_center_strict` | `assign_centers` | `histogram` | Value-count struct per cell. `--agg` is ignored. |
-| `point_sample_field` | `sample_nn` | `value` | Nearest-neighbour sample at each DGGS cell centre. `--agg` is ignored. Supports `--compact`. |
-| `piecewise_constant` | `sample_nn` | `value` | Nearest-neighbour sample at each DGGS cell centre. Suitable for categorical rasters (landcover, zone IDs, soil class). `--agg` is ignored. Supports `--compact`. |
+| `point_sample_field` | `sample` | `value` | Nearest-neighbour sample at each DGGS cell centre (`--interp nn`). `--agg` is ignored. Supports `--compact`. |
+| `piecewise_constant` | `sample` | `value` | Nearest-neighbour sample at each DGGS cell centre (`--interp nn`). Suitable for categorical rasters (landcover, zone IDs, soil class). `--agg` is ignored. Supports `--compact`. |
 
 All other valid combinations will raise a `NotImplementedError` with a descriptive message until they are added.
 
@@ -500,8 +503,8 @@ To run a subset of tests:
 ```bash
 pytest -k h3                        # all tests whose ID contains "h3"
 pytest -k "h3 or rhp"
-pytest -k "sample_nn and rhp"
-pytest tests/classes/test_sample_nn.py          # single file
+pytest -k "sample and rhp"
+pytest tests/classes/test_sample_nn.py          # sample transfer smoke tests
 pytest "tests/classes/test_cli_integration.py::TestAllDGGS::test_command[h3-polygon-co]"  # exact parametrized case
 ```
 
@@ -583,12 +586,12 @@ raster2dggs h3 --resolution 7 --out histogram -d 0 input.tif ./output
 
 Nearest-neighbour sampling for a continuous field (e.g. DEM, temperature grid):
 ```bash
-raster2dggs h3 --resolution 9 --semantics point_sample_field --transfer sample_nn input.tif ./output
+raster2dggs h3 --resolution 9 --semantics point_sample_field --transfer sample input.tif ./output
 ```
 
 Nearest-neighbour sampling for a categorical raster (e.g. landcover):
 ```bash
-raster2dggs h3 --resolution 9 --semantics piecewise_constant --transfer sample_nn -d 0 landcover.tif ./output
+raster2dggs h3 --resolution 9 --semantics piecewise_constant --transfer sample -d 0 landcover.tif ./output
 ```
 
 Emit nodata cells rather than omitting them, replacing the nodata value with −1:

--- a/make_samples.py
+++ b/make_samples.py
@@ -449,21 +449,18 @@ def make_satellite_swath(outdir, rng):
     R = 6_371_000.0
     cross_track_m = (
         np.arcsin(
-            np.clip(
-                np.sin(dist_AP / R) * np.sin(np.radians(az_AP - az_AB)), -1.0, 1.0
-            )
+            np.clip(np.sin(dist_AP / R) * np.sin(np.radians(az_AP - az_AB)), -1.0, 1.0)
         )
         * R
     )
 
     # Swath half-width in metres + gentle along-track edge noise
     half_w_m = 220_000.0
-    edge_noise_l = (smooth(rng.random((h, w), dtype=np.float32), 20) * 40_000 - 20_000)
-    edge_noise_r = (smooth(rng.random((h, w), dtype=np.float32), 20) * 40_000 - 20_000)
+    edge_noise_l = smooth(rng.random((h, w), dtype=np.float32), 20) * 40_000 - 20_000
+    edge_noise_r = smooth(rng.random((h, w), dtype=np.float32), 20) * 40_000 - 20_000
 
-    inside = (
-        (cross_track_m > -half_w_m + edge_noise_l)
-        & (cross_track_m < half_w_m + edge_noise_r)
+    inside = (cross_track_m > -half_w_m + edge_noise_l) & (
+        cross_track_m < half_w_m + edge_noise_r
     )
     data[:, ~inside] = nodata
 
@@ -502,22 +499,21 @@ def make_u_shape_swath(outdir, rng):
 
     crs = pyproj.CRS.from_epsg(3031)
 
-    px = 10_000.0    # 10 km — coarse is fine; this is a geometry stress test
+    px = 10_000.0  # 10 km — coarse is fine; this is a geometry stress test
     w, h = 2_000, 200  # 20 000 km wide × 2 000 km tall
     cx, cy = 0, 16_000_000  # centre: 16 000 km from south pole, mid-latitudes N
 
     transform = from_origin(
-        cx - w / 2 * px,   # left edge
-        cy + h / 2 * px,   # top edge (northernmost y in EPSG:3031)
+        cx - w / 2 * px,  # left edge
+        cy + h / 2 * px,  # top edge (northernmost y in EPSG:3031)
         px,
         px,
     )
 
     # Single-band continuous data
-    data = (
-        (nlm_fractal((h, w), rng, octaves=4, persistence=0.55) * 3000)
-        .astype(np.float32)[np.newaxis, ...]
-    )
+    data = (nlm_fractal((h, w), rng, octaves=4, persistence=0.55) * 3000).astype(
+        np.float32
+    )[np.newaxis, ...]
 
     path = os.path.join(outdir, "swath_u_shape.tif")
     write_geotiff(
@@ -552,22 +548,25 @@ def make_satellite_swath_projected(outdir, rng):
     Pixel size: 2 km.  Dimensions: 100 × 2 500 pixels (200 km × 5 000 km).
     """
     import pyproj
+
     # Use pyproj to construct the CRS so it generates proper WKT2 with a
     # named datum — rasterio's CRS.from_proj4 only embeds an ellipsoid,
     # which QGIS cannot resolve to a known CRS.
-    crs = pyproj.CRS.from_dict({
-        "proj": "stere",
-        "lat_0": 90,
-        "lat_ts": 70,
-        "lon_0": 145,
-        "x_0": 0,
-        "y_0": 0,
-        "datum": "WGS84",
-        "units": "m",
-    })
+    crs = pyproj.CRS.from_dict(
+        {
+            "proj": "stere",
+            "lat_0": 90,
+            "lat_ts": 70,
+            "lon_0": 145,
+            "x_0": 0,
+            "y_0": 0,
+            "datum": "WGS84",
+            "units": "m",
+        }
+    )
 
     px = 2_000.0
-    w, h = 100, 2_500   # 200 km across-track × 5 000 km along-track
+    w, h = 100, 2_500  # 200 km across-track × 5 000 km along-track
 
     # Offset 400 km east of the central meridian so the strip curves in WGS84
     # without crossing the antimeridian.

--- a/raster2dggs/cli_factory.py
+++ b/raster2dggs/cli_factory.py
@@ -164,6 +164,7 @@ def run_index(
     tempdir,
     semantics: str,
     transfer: str,
+    interp: str,
     out: str,
 ):
     tempfile.tempdir = tempdir if tempdir is not None else tempfile.tempdir
@@ -182,6 +183,7 @@ def run_index(
         geo,
         semantics,
         transfer,
+        interp,
         out,
     )
 
@@ -305,6 +307,13 @@ def make_command(spec: DGGS_Spec):
         help="How values are mapped from raster pixels to DGGS cells.",
     )
     @click.option(
+        "--interp",
+        default=const.Interp.NN.value,
+        type=click.Choice([i.value for i in const.Interp]),
+        show_default=True,
+        help="Interpolation method used with --transfer sample. Ignored for other transfer operators.",
+    )
+    @click.option(
         "--out",
         default=const.OutputSchema.VALUE.value,
         type=click.Choice([o.value for o in const.OutputSchema]),
@@ -357,6 +366,7 @@ def make_command(spec: DGGS_Spec):
         tempdir,
         semantics,
         transfer,
+        interp,
         out,
     ):
         if isinstance(resolution, str):
@@ -381,9 +391,9 @@ def make_command(spec: DGGS_Spec):
             common.LOGGER.warning(
                 f"--out {out!r}: --agg has no effect (all contributing values are collected)"
             )
-        if transfer == const.Transfer.SAMPLE_NN.value and agg_from_cli:
+        if transfer == const.Transfer.SAMPLE.value and agg_from_cli:
             common.LOGGER.warning(
-                "--transfer sample_nn: --agg has no effect (one sample per DGGS cell)"
+                "--transfer sample: --agg has no effect (one sample per DGGS cell)"
             )
         return run_index(
             spec.name,
@@ -404,6 +414,7 @@ def make_command(spec: DGGS_Spec):
             tempdir,
             semantics,
             transfer,
+            interp,
             out,
         )
 

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -41,6 +41,8 @@ from raster2dggs.indexers.rasterindexer import _is_nan
 LOGGER = logging.getLogger(__name__)
 click_log.basic_config(LOGGER)
 
+from raster2dggs.interpolation import _SampleIndexer
+
 
 class ParentResolutionException(Exception):
     pass
@@ -228,7 +230,7 @@ def write_partition_as_geoparquet(
     # Compute GeoParquet 1.1.0 extras
     valid = [g for g in geoms if (g is not None and not g.is_empty)]
     if len(valid):
-        arr = np.asarray(shapely.bounds(geoms))  # Shapely 2.x vectorized
+        arr = np.asarray(shapely.bounds(geoms))  # Shapely 2.x vectorised
         m = ~np.isnan(arr).any(axis=1)
         bbox_vals = arr[m]
         bbox = [
@@ -279,6 +281,174 @@ def write_partition_as_geoparquet(
     )
 
 
+def _element_type(src_dtype, decimals) -> pa.DataType:
+    if decimals is not None and decimals <= 0:
+        return pa.int64()
+    if decimals is not None:  # decimals > 0: always float64
+        return pa.float64()
+    return pa.from_numpy_dtype(src_dtype)
+
+
+def _build_output_meta(
+    *,
+    transfer: str,
+    out: str,
+    aggfuncs: list,
+    decimals,
+    source_dtypes: dict,
+    band_cols: list,
+    partition_col: str,
+    index_col: str,
+    compact: bool,
+    interp: str,
+) -> tuple[pd.DataFrame, str]:
+    if transfer == const.Transfer.SAMPLE or (out == "value" and len(aggfuncs) == 1):
+        out_meta = pd.DataFrame(
+            {
+                partition_col: pd.Series([], dtype="string"),
+                **{
+                    c: pd.Series(
+                        [],
+                        dtype=(
+                            "Int64"
+                            if decimals is not None and decimals <= 0
+                            # decimals > 0: always float64 regardless of source
+                            # dtype — aggregations on integer rasters (e.g. mean)
+                            # produce floats, and rounding to dp implies a float result
+                            else "float64" if decimals is not None else source_dtypes[c]
+                        ),
+                    )
+                    for c in band_cols
+                },
+            }
+        )
+        _compacting = "/compacting" if compact else ""
+        if transfer == const.Transfer.SAMPLE:
+            tqdm_label = f"Sampling ({interp}){_compacting}"
+        else:
+            tqdm_label = f"Aggregating{_compacting}"
+    else:
+        # list, histogram, or multi-agg value — object-typed columns
+        out_meta = pd.DataFrame(
+            {
+                partition_col: pd.Series([], dtype="string"),
+                **{c: pd.Series([], dtype="object") for c in band_cols},
+            }
+        )
+        tqdm_label = (
+            "Collecting"
+            if out != "value"
+            else f"Aggregating{'/compacting' if compact else ''}"
+        )
+    out_meta.index = pd.Index([], name=index_col, dtype="string")
+    return out_meta, tqdm_label
+
+
+def _build_write_schema(
+    *,
+    out: str,
+    aggfuncs: list,
+    band_cols: list,
+    decimals,
+    source_dtypes: dict,
+    index_col: str,
+    partition_col: str,
+    out_meta: pd.DataFrame,
+) -> pa.Schema:
+    common_fields = [
+        pa.field(index_col, pa.string()),
+        pa.field(partition_col, pa.string()),
+    ]
+    if out == "list":
+        return pa.schema(
+            common_fields
+            + [
+                pa.field(c, pa.list_(_element_type(source_dtypes[c], decimals)))
+                for c in band_cols
+            ]
+        )
+    if out == "histogram":
+        return pa.schema(
+            common_fields
+            + [
+                pa.field(
+                    c,
+                    pa.struct(
+                        [
+                            pa.field(
+                                "values",
+                                pa.list_(_element_type(source_dtypes[c], decimals)),
+                            ),
+                            pa.field("counts", pa.list_(pa.int64())),
+                        ]
+                    ),
+                )
+                for c in band_cols
+            ]
+        )
+    if len(aggfuncs) > 1:
+        return pa.schema(
+            common_fields
+            + [
+                pa.field(
+                    c,
+                    pa.struct(
+                        [
+                            pa.field(
+                                agg_name, _element_type(source_dtypes[c], decimals)
+                            )
+                            for agg_name, _ in aggfuncs
+                        ]
+                    ),
+                )
+                for c in band_cols
+            ]
+        )
+    return pa.Schema.from_pandas(out_meta, preserve_index=True)
+
+
+def _write_output(
+    ddf,
+    *,
+    output: Path,
+    geo,
+    compression: str,
+    partition_col: str,
+    overwrite: bool,
+    write_schema: pa.Schema,
+    indexer: IRasterIndexer,
+) -> None:
+    if geo:
+        delayed_parts = ddf.to_delayed()
+        geo_serialisation_method = (
+            indexer.cell_to_polygon if geo == "polygon" else indexer.cell_to_point
+        )
+        write_tasks = [
+            dask.delayed(write_partition_as_geoparquet)(
+                part,
+                geo_serialisation_method,
+                output,
+                partition_col,
+                compression,
+                write_schema,
+            )
+            for part in delayed_parts
+        ]
+        with TqdmCallback(desc="Writing GeoParquet"):
+            dask.compute(*write_tasks)
+    else:
+        ddf.to_parquet(
+            output,
+            engine="pyarrow",
+            partition_on=[partition_col],
+            overwrite=overwrite,
+            write_index=True,
+            append=False,
+            compression=compression,
+            schema=write_schema,
+        )
+
+
 def address_boundary_issues(
     indexer: IRasterIndexer,
     pq_input: tempfile.TemporaryDirectory,
@@ -306,69 +476,36 @@ def address_boundary_issues(
     index_col = indexer.index_col(resolution)
     partition_col = indexer.partition_col(parent_res)
 
-    part_schema = pa.schema(
-        [(partition_col, pa.string())]
-    )  # Don't let this be inferred; e.g. geohash levels can be inferred variously as int or string
-    # Keep hive partitions; coalese files per partition
+    # Don't let partition schema be inferred; e.g. geohash levels can be
+    # inferred variously as int or string.
+    part_schema = pa.schema([(partition_col, pa.string())])
     ddf = dd.read_parquet(
         pq_input,
         engine="pyarrow",
         aggregate_files=True,
         dataset={"partitioning": ds.partitioning(part_schema, flavor="hive")},
     )
-    # Cols to aggregate (bands only)
     band_cols = [c for c in ddf.columns if not c.startswith(f"{indexer.dggs}_")]
-    # Capture source dtypes before map_partitions changes them
+    # Capture source dtypes before map_partitions changes them.
     source_dtypes = {c: ddf[c].dtype for c in band_cols}
 
     out = kwargs.get("out", "value")
     transfer = kwargs.get("transfer", const.Transfer.ASSIGN_CENTERS)
-
     decimals = kwargs.get("decimals")
-
     aggfuncs = kwargs.get("aggfuncs", [("mean", "mean")])
 
-    if transfer == const.Transfer.SAMPLE or out == "value" and len(aggfuncs) == 1:
-        out_meta = pd.DataFrame(
-            {
-                partition_col: pd.Series([], dtype="string"),
-                **{
-                    c: pd.Series(
-                        [],
-                        dtype=(
-                            "Int64" if decimals is not None and decimals <= 0
-                            # decimals > 0: always float64 regardless of source
-                            # dtype — aggregations on integer rasters (e.g. mean)
-                            # produce floats, and rounding to dp implies a float result
-                            else "float64" if decimals is not None
-                            else source_dtypes[c]
-                        ),
-                    )
-                    for c in band_cols
-                },
-            }
-        )
-        _compacting = "/compacting" if kwargs["compact"] else ""
-        tqdm_label = (
-            f"Sampling (nearest neighbour){_compacting}"
-            if transfer == const.Transfer.SAMPLE
-            else f"Aggregating{_compacting}"
-        )
-    else:
-        # list, histogram, or multi-agg value — object-typed columns
-        out_meta = pd.DataFrame(
-            {
-                partition_col: pd.Series([], dtype="string"),
-                **{c: pd.Series([], dtype="object") for c in band_cols},
-            }
-        )
-        tqdm_label = (
-            "Collecting"
-            if out != "value"
-            else f"Aggregating{'/compacting' if kwargs['compact'] else ''}"
-        )
-
-    out_meta.index = pd.Index([], name=index_col, dtype="string")
+    out_meta, tqdm_label = _build_output_meta(
+        transfer=transfer,
+        out=out,
+        aggfuncs=aggfuncs,
+        decimals=decimals,
+        source_dtypes=source_dtypes,
+        band_cols=band_cols,
+        partition_col=partition_col,
+        index_col=index_col,
+        compact=kwargs["compact"],
+        interp=kwargs.get("interp", const.Interp.NN),
+    )
 
     with TqdmCallback(desc=tqdm_label):
         if transfer == const.Transfer.SAMPLE:
@@ -391,117 +528,56 @@ def address_boundary_issues(
                 indexer.compaction, resolution, parent_res, meta=out_meta
             )
 
-        def _element_type(src_dtype):
-            if decimals is not None and decimals <= 0:
-                return pa.int64()
-            if decimals is not None:  # decimals > 0: always float64
-                return pa.float64()
-            return pa.from_numpy_dtype(src_dtype)
+        write_schema = _build_write_schema(
+            out=out,
+            aggfuncs=aggfuncs,
+            band_cols=band_cols,
+            decimals=decimals,
+            source_dtypes=source_dtypes,
+            index_col=index_col,
+            partition_col=partition_col,
+            out_meta=out_meta,
+        )
 
-        common_fields = [
-            pa.field(index_col, pa.string()),
-            pa.field(partition_col, pa.string()),
-        ]
-        if out == "list":
-            write_schema = pa.schema(
-                common_fields
-                + [
-                    pa.field(c, pa.list_(_element_type(source_dtypes[c])))
-                    for c in band_cols
-                ]
-            )
-        elif out == "histogram":
-            write_schema = pa.schema(
-                common_fields
-                + [
-                    pa.field(
-                        c,
-                        pa.struct(
-                            [
-                                pa.field(
-                                    "values",
-                                    pa.list_(_element_type(source_dtypes[c])),
-                                ),
-                                pa.field("counts", pa.list_(pa.int64())),
-                            ]
-                        ),
-                    )
-                    for c in band_cols
-                ]
-            )
-        elif len(aggfuncs) > 1:
-            write_schema = pa.schema(
-                common_fields
-                + [
-                    pa.field(
-                        c,
-                        pa.struct(
-                            [
-                                pa.field(agg_name, _element_type(source_dtypes[c]))
-                                for agg_name, _ in aggfuncs
-                            ]
-                        ),
-                    )
-                    for c in band_cols
-                ]
-            )
-        else:
-            write_schema = pa.Schema.from_pandas(out_meta, preserve_index=True)
-
-        if kwargs["geo"]:
-
-            # Create one delayed write task per Dask partition
-            delayed_parts = ddf.to_delayed()
-
-            geo_serialisation_method = (
-                indexer.cell_to_polygon
-                if kwargs["geo"] == "polygon"
-                else indexer.cell_to_point
-            )
-
-            write_tasks = [
-                dask.delayed(write_partition_as_geoparquet)(
-                    part,
-                    geo_serialisation_method,
-                    output,
-                    partition_col,
-                    kwargs["compression"],
-                    write_schema,
-                )
-                for part in delayed_parts
-            ]
-
-            # Execute writes with progress
-            with TqdmCallback(desc="Writing GeoParquet"):
-                dask.compute(*write_tasks)
-
-        else:
-            ddf.to_parquet(
-                output,
-                engine="pyarrow",
-                partition_on=[partition_col],
-                overwrite=kwargs["overwrite"],
-                write_index=True,
-                append=False,
-                compression=kwargs["compression"],
-                schema=write_schema,
-            )
+        _write_output(
+            ddf,
+            output=output,
+            geo=kwargs["geo"],
+            compression=kwargs["compression"],
+            partition_col=partition_col,
+            overwrite=kwargs["overwrite"],
+            write_schema=write_schema,
+            indexer=indexer,
+        )
 
     LOGGER.debug("Stage 2 (aggregation) complete")
-
     return output
 
 
-def validate_transfer_config(semantics: str, transfer: str, out: str) -> None:
+def validate_transfer_config(
+    semantics: str, transfer: str, interp: str, out: str
+) -> None:
     if (semantics, transfer) in const.INAPPROPRIATE:
         raise click.UsageError(
             f"--transfer {transfer!r} is inappropriate for --semantics {semantics!r}. "
             f"See the semantics × transfer matrix in the documentation."
         )
-    if (semantics, transfer, out) not in const.IMPLEMENTED:
+    if (semantics, transfer, interp) in const.INAPPROPRIATE_INTERP:
+        raise click.UsageError(
+            f"--transfer {transfer!r} --interp {interp!r} is inappropriate for "
+            f"--semantics {semantics!r}. "
+            f"See the semantics × transfer matrix in the documentation."
+        )
+    lookup = (
+        (semantics, transfer, interp, out)
+        if transfer == const.Transfer.SAMPLE
+        else (semantics, transfer, out)
+    )
+    if lookup not in const.IMPLEMENTED:
         raise NotImplementedError(
-            f"--semantics {semantics!r} / --transfer {transfer!r} / --out {out!r} "
-            f"is a valid combination but is not yet implemented."
+            f"--semantics {semantics!r} / --transfer {transfer!r}"
+            + (f" / --interp {interp!r}" if transfer == const.Transfer.SAMPLE else "")
+            + f" / --out {out!r} is a valid combination but is not yet implemented."
         )
 
 
@@ -523,10 +599,15 @@ def initial_index(
     pyproj.Transformer, preserving original raster values without resampling.
 
     This function passes a path to a temporary directory (which contains
-        the output of this "stage 1" processing) to a secondary function
-        that addresses issues at the boundaries of raster windows.
+    the output of this "stage 1" processing) to a secondary function
+    that addresses issues at the boundaries of raster windows.
     """
-    validate_transfer_config(kwargs["semantics"], kwargs["transfer"], kwargs["out"])
+    validate_transfer_config(
+        kwargs["semantics"],
+        kwargs["transfer"],
+        kwargs.get("interp", const.Interp.NN),
+        kwargs["out"],
+    )
 
     indexer = idxfactory.indexer_instance(dggs)
 
@@ -660,123 +741,34 @@ def initial_index(
                     _write_result(result, window)
                     return None
 
-                def _enumerate_cells(window):
-                    """
-                    Return (cells, local_rows, local_cols) for all DGGS cells
-                    whose nearest-neighbour pixel falls inside *window*, or
-                    (None, None, None) if no cells qualify.
-
-                    local_rows and local_cols are relative to window.row_off /
-                    window.col_off, so they index directly into an array read
-                    with da.rio.isel_window(window).
-                    """
-                    win_left, win_bottom, win_right, win_top = src.window_bounds(window)
-                    min_lon, min_lat, max_lon, max_lat = transform_bounds(
-                        src.crs, "EPSG:4326", win_left, win_bottom, win_right, win_top
+                ctx = None
+                if kwargs["transfer"] == const.Transfer.SAMPLE:
+                    ctx = _SampleIndexer(
+                        src=src,
+                        da=da,
+                        inverse_transformer=inverse_transformer,
+                        nodata=nodata,
+                        indexer=indexer,
+                        resolution=resolution,
+                        parent_res=parent_res,
+                        selected_labels=selected_labels,
+                        nodata_policy=nodata_policy,
+                        emit_nodata_value=emit_nodata_value,
+                        write_result=_write_result,
                     )
 
-                    cells = list(
-                        indexer.cells_in_bbox(
-                            min_lon, min_lat, max_lon, max_lat, resolution
-                        )
-                    )
-                    if not cells:
-                        return None, None, None
-
-                    cell_lons, cell_lats = indexer.cells_to_lonlat_arrays(
-                        pd.Series(cells)
-                    )
-                    # Pass as Python lists to avoid pyproj trying float(array)
-                    # on 1-element numpy arrays, which triggers a NumPy
-                    # DeprecationWarning via the _transform_point fast path.
-                    _xs, _ys = inverse_transformer.transform(
-                        cell_lons.tolist(), cell_lats.tolist()
-                    )
-                    all_rows, all_cols = rowcol(
-                        src.transform, np.asarray(_xs), np.asarray(_ys)
-                    )
-                    all_rows = np.asarray(all_rows)
-                    all_cols = np.asarray(all_cols)
-
-                    # Keep only cells whose nearest pixel is in this window.
-                    # A pixel belongs to exactly one window, so each cell is
-                    # processed exactly once across all windows.
-                    local_rows = all_rows - window.row_off
-                    local_cols = all_cols - window.col_off
-                    in_win = (
-                        (local_rows >= 0)
-                        & (local_rows < window.height)
-                        & (local_cols >= 0)
-                        & (local_cols < window.width)
-                    )
-                    if not np.any(in_win):
-                        return None, None, None
-
-                    return (
-                        [c for c, m in zip(cells, in_win) if m],
-                        local_rows[in_win],
-                        local_cols[in_win],
-                    )
-
-                def process_nn(window):
-                    cells, local_rows, local_cols = _enumerate_cells(window)
-                    if cells is None:
-                        return None
-
-                    # da has dims (band, y, x); .values triggers Dask compute
-                    win_data = da.rio.isel_window(window).values
-                    samples = win_data[:, local_rows, local_cols].T
-                    # samples: (n_cells, n_bands)
-
-                    # nodata handling
-                    if nodata is None:
-                        nd_mask = np.zeros(len(cells), dtype=bool)
-                    elif _is_nan(nodata):
-                        nd_mask = np.any(np.isnan(samples.astype(float)), axis=1)
+                if kwargs["transfer"] == const.Transfer.SAMPLE:
+                    interp = kwargs.get("interp", const.Interp.NN)
+                    if interp == const.Interp.BILINEAR:
+                        stage1_func = ctx.process_bilinear
+                    elif interp == const.Interp.BICUBIC:
+                        stage1_func = ctx.process_bicubic
+                    elif interp == const.Interp.LANCZOS:
+                        stage1_func = ctx.process_lanczos
                     else:
-                        nd_mask = np.any(samples == nodata, axis=1) | np.any(
-                            np.isnan(samples.astype(float)), axis=1
-                        )
-
-                    wide = pd.DataFrame(
-                        {
-                            label: samples[:, i]
-                            for i, label in enumerate(selected_labels)
-                        }
-                    )
-                    index_col = indexer.index_col(resolution)
-                    partition_col = indexer.partition_col(parent_res)
-                    wide[index_col] = cells
-                    wide[partition_col] = list(
-                        indexer.single_parent_cells(cells, parent_res)
-                    )
-
-                    if nodata_policy.lower() == "omit":
-                        wide = wide[~nd_mask].reset_index(drop=True)
-                    elif nodata_policy.lower() == "emit":
-                        fill = (
-                            emit_nodata_value
-                            if emit_nodata_value is not None
-                            else nodata
-                        )
-                        for label in selected_labels:
-                            if pd.isna(fill):
-                                wide.loc[nd_mask, label] = np.nan
-                            else:
-                                wide.loc[nd_mask, label] = fill
-
-                    if wide.empty:
-                        return None
-
-                    result = pa.Table.from_pandas(wide, preserve_index=False)
-                    _write_result(result, window)
-                    return None
-
-                stage1_func = (
-                    process_nn
-                    if kwargs["transfer"] == const.Transfer.SAMPLE
-                    else process
-                )
+                        stage1_func = ctx.process_nn
+                else:
+                    stage1_func = process
                 try:
                     with ThreadPoolExecutor(
                         max_workers=kwargs["threads"]
@@ -795,7 +787,7 @@ def initial_index(
                     # rather than at interpreter shutdown (which causes a
                     # silent "Error in sys.excepthook" crash for non-WGS84
                     # rasters).
-                    del da, transformer, process, _enumerate_cells, process_nn, stage1_func
+                    del da, transformer, process, ctx, stage1_func
                     gc.collect()
             LOGGER.debug("Stage 1 (primary indexing) complete")
             return address_boundary_issues(

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -196,6 +196,7 @@ def assemble_kwargs(
     geo: str,
     semantics: str = const.Semantics.POINT_CENTER_STRICT,
     transfer: str = const.Transfer.ASSIGN_CENTERS,
+    interp: str = const.Interp.NN,
     out: str = const.OutputSchema.VALUE,
 ) -> dict:
     return {
@@ -208,6 +209,7 @@ def assemble_kwargs(
         "geo": geo if geo != "none" else None,
         "semantics": semantics,
         "transfer": transfer,
+        "interp": interp,
         "out": out,
     }
 
@@ -326,7 +328,7 @@ def address_boundary_issues(
 
     aggfuncs = kwargs.get("aggfuncs", [("mean", "mean")])
 
-    if transfer == const.Transfer.SAMPLE_NN or out == "value" and len(aggfuncs) == 1:
+    if transfer == const.Transfer.SAMPLE or out == "value" and len(aggfuncs) == 1:
         out_meta = pd.DataFrame(
             {
                 partition_col: pd.Series([], dtype="string"),
@@ -349,7 +351,7 @@ def address_boundary_issues(
         _compacting = "/compacting" if kwargs["compact"] else ""
         tqdm_label = (
             f"Sampling (nearest neighbour){_compacting}"
-            if transfer == const.Transfer.SAMPLE_NN
+            if transfer == const.Transfer.SAMPLE
             else f"Aggregating{_compacting}"
         )
     else:
@@ -369,7 +371,7 @@ def address_boundary_issues(
     out_meta.index = pd.Index([], name=index_col, dtype="string")
 
     with TqdmCallback(desc=tqdm_label):
-        if transfer == const.Transfer.SAMPLE_NN:
+        if transfer == const.Transfer.SAMPLE:
             mp_func = indexer.parent_groupby_nn
             mp_args = (resolution, parent_res, decimals)
         elif out == "list":
@@ -529,11 +531,11 @@ def initial_index(
     indexer = idxfactory.indexer_instance(dggs)
 
     if (
-        kwargs["transfer"] == const.Transfer.SAMPLE_NN
+        kwargs["transfer"] == const.Transfer.SAMPLE
         and not indexer.SUPPORTS_CELL_ENUMERATION
     ):
         raise click.UsageError(
-            f"--transfer sample_nn requires spatial cell enumeration, which is not "
+            f"--transfer sample requires spatial cell enumeration, which is not "
             f"supported by the {dggs!r} DGGS."
         )
 
@@ -590,7 +592,7 @@ def initial_index(
                     src.crs, "EPSG:4326", always_xy=True
                 )
                 LOGGER.debug("Coordinate transformer: %s → EPSG:4326", src.crs)
-                if kwargs["transfer"] == const.Transfer.SAMPLE_NN:
+                if kwargs["transfer"] == const.Transfer.SAMPLE:
                     inverse_transformer = pyproj.Transformer.from_crs(
                         "EPSG:4326", src.crs, always_xy=True
                     )
@@ -658,18 +660,16 @@ def initial_index(
                     _write_result(result, window)
                     return None
 
-                def process_nn(window):
+                def _enumerate_cells(window):
                     """
-                    Cell-driven stage-1 for sample_nn.
+                    Return (cells, local_rows, local_cols) for all DGGS cells
+                    whose nearest-neighbour pixel falls inside *window*, or
+                    (None, None, None) if no cells qualify.
 
-                    Enumerates every DGGS cell whose centre falls within the
-                    window's geographic bbox, converts each centre to the
-                    nearest raster pixel in this window, reads the value, and
-                    writes one row per cell.  Because a pixel belongs to exactly
-                    one window, each cell is written once — stage-2 deduplication
-                    is a no-op in practice but still handles edge cases.
+                    local_rows and local_cols are relative to window.row_off /
+                    window.col_off, so they index directly into an array read
+                    with da.rio.isel_window(window).
                     """
-                    # bbox of this window in WGS84
                     win_left, win_bottom, win_right, win_top = src.window_bounds(window)
                     min_lon, min_lat, max_lon, max_lat = transform_bounds(
                         src.crs, "EPSG:4326", win_left, win_bottom, win_right, win_top
@@ -681,9 +681,8 @@ def initial_index(
                         )
                     )
                     if not cells:
-                        return None
+                        return None, None, None
 
-                    # cell centres → raster pixel coords
                     cell_lons, cell_lats = indexer.cells_to_lonlat_arrays(
                         pd.Series(cells)
                     )
@@ -693,13 +692,13 @@ def initial_index(
                     _xs, _ys = inverse_transformer.transform(
                         cell_lons.tolist(), cell_lats.tolist()
                     )
-                    cell_xs = np.asarray(_xs)
-                    cell_ys = np.asarray(_ys)
-                    all_rows, all_cols = rowcol(src.transform, cell_xs, cell_ys)
+                    all_rows, all_cols = rowcol(
+                        src.transform, np.asarray(_xs), np.asarray(_ys)
+                    )
                     all_rows = np.asarray(all_rows)
                     all_cols = np.asarray(all_cols)
 
-                    # Keep only cells whose sample pixel is in this window.
+                    # Keep only cells whose nearest pixel is in this window.
                     # A pixel belongs to exactly one window, so each cell is
                     # processed exactly once across all windows.
                     local_rows = all_rows - window.row_off
@@ -711,13 +710,19 @@ def initial_index(
                         & (local_cols < window.width)
                     )
                     if not np.any(in_win):
+                        return None, None, None
+
+                    return (
+                        [c for c, m in zip(cells, in_win) if m],
+                        local_rows[in_win],
+                        local_cols[in_win],
+                    )
+
+                def process_nn(window):
+                    cells, local_rows, local_cols = _enumerate_cells(window)
+                    if cells is None:
                         return None
 
-                    cells = [c for c, m in zip(cells, in_win) if m]
-                    local_rows = local_rows[in_win]
-                    local_cols = local_cols[in_win]
-
-                    # read window data and sample at cell-centre pixels:
                     # da has dims (band, y, x); .values triggers Dask compute
                     win_data = da.rio.isel_window(window).values
                     samples = win_data[:, local_rows, local_cols].T
@@ -769,7 +774,7 @@ def initial_index(
 
                 stage1_func = (
                     process_nn
-                    if kwargs["transfer"] == const.Transfer.SAMPLE_NN
+                    if kwargs["transfer"] == const.Transfer.SAMPLE
                     else process
                 )
                 try:
@@ -790,7 +795,7 @@ def initial_index(
                     # rather than at interpreter shutdown (which causes a
                     # silent "Error in sys.excepthook" crash for non-WGS84
                     # rasters).
-                    del da, transformer, process, process_nn, stage1_func
+                    del da, transformer, process, _enumerate_cells, process_nn, stage1_func
                     gc.collect()
             LOGGER.debug("Stage 1 (primary indexing) complete")
             return address_boundary_issues(

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -145,11 +145,14 @@ class Semantics(StrEnum):
 
 class Transfer(StrEnum):
     ASSIGN_CENTERS = "assign_centers"
-    SAMPLE_NN = "sample_nn"
-    SAMPLE_INTERP = "sample_interp"
+    SAMPLE = "sample"
     OVERLAY_WEIGHTED = "overlay_weighted"
     OVERLAY_MODE = "overlay_mode"
     MASS_PRESERVE = "mass_preserve"
+
+
+class Interp(StrEnum):
+    NN = "nn"
 
 
 class OutputSchema(StrEnum):
@@ -161,8 +164,7 @@ class OutputSchema(StrEnum):
 
 INAPPROPRIATE: set = {
     # point_center_strict: only assign_centers is appropriate
-    ("point_center_strict", "sample_nn"),
-    ("point_center_strict", "sample_interp"),
+    ("point_center_strict", "sample"),
     ("point_center_strict", "overlay_weighted"),
     ("point_center_strict", "overlay_mode"),
     ("point_center_strict", "mass_preserve"),
@@ -170,39 +172,36 @@ INAPPROPRIATE: set = {
     ("point_sample_field", "assign_centers"),
     # cell_average: must use area-weighted overlay
     ("cell_average", "assign_centers"),
-    ("cell_average", "sample_nn"),
-    ("cell_average", "sample_interp"),
+    ("cell_average", "sample"),
     ("cell_average", "overlay_mode"),
     ("cell_average", "mass_preserve"),
-    # piecewise_constant: assign_centers ignores pixel area; interp and mass wrong
+    # piecewise_constant: assign_centers ignores pixel area; mass wrong
+    # Note: sample --interp nn is valid; sample --interp bilinear/bicubic is not.
+    # Interp-specific restrictions are enforced separately when non-nn interp is added.
     ("piecewise_constant", "assign_centers"),
-    ("piecewise_constant", "sample_interp"),
     ("piecewise_constant", "mass_preserve"),
     # fraction_cover: values are areal fractions; point-based methods are wrong
     ("fraction_cover", "assign_centers"),
-    ("fraction_cover", "sample_nn"),
+    ("fraction_cover", "sample"),
     ("fraction_cover", "overlay_mode"),
     ("fraction_cover", "mass_preserve"),
     # count_total: totals require mass preservation; sampling breaks conservation
     ("count_total", "assign_centers"),
-    ("count_total", "sample_nn"),
-    ("count_total", "sample_interp"),
+    ("count_total", "sample"),
     ("count_total", "overlay_weighted"),
     ("count_total", "overlay_mode"),
     # density: per-area intensity; assign_centers and overlay_mode are wrong
     ("density", "assign_centers"),
     ("density", "overlay_mode"),
     ("density", "mass_preserve"),
-    # event_indicator: interpolation is meaningless for discrete events
-    ("event_indicator", "sample_interp"),
 }
 
 IMPLEMENTED: set = {
     ("point_center_strict", "assign_centers", "value"),
     ("point_center_strict", "assign_centers", "list"),
     ("point_center_strict", "assign_centers", "histogram"),
-    ("point_sample_field", "sample_nn", "value"),
-    ("piecewise_constant", "sample_nn", "value"),
+    ("point_sample_field", "sample", "value"),
+    ("piecewise_constant", "sample", "value"),
 }
 
 

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -153,6 +153,9 @@ class Transfer(StrEnum):
 
 class Interp(StrEnum):
     NN = "nn"
+    BILINEAR = "bilinear"
+    BICUBIC = "bicubic"
+    LANCZOS = "lanczos"
 
 
 class OutputSchema(StrEnum):
@@ -196,12 +199,27 @@ INAPPROPRIATE: set = {
     ("density", "mass_preserve"),
 }
 
+INAPPROPRIATE_INTERP: set = {
+    # piecewise_constant: smooth interpolation between categorical values is meaningless
+    ("piecewise_constant", "sample", "bilinear"),
+    ("piecewise_constant", "sample", "bicubic"),
+    ("piecewise_constant", "sample", "lanczos"),
+    # event_indicator: smooth interpolation of discrete events produces fractional nonsense
+    ("event_indicator", "sample", "bilinear"),
+    ("event_indicator", "sample", "bicubic"),
+    ("event_indicator", "sample", "lanczos"),
+}
+
 IMPLEMENTED: set = {
     ("point_center_strict", "assign_centers", "value"),
     ("point_center_strict", "assign_centers", "list"),
     ("point_center_strict", "assign_centers", "histogram"),
-    ("point_sample_field", "sample", "value"),
-    ("piecewise_constant", "sample", "value"),
+    # sample transfer uses 4-tuples: (semantics, transfer, interp, out)
+    ("point_sample_field", "sample", "nn", "value"),
+    ("piecewise_constant", "sample", "nn", "value"),
+    ("point_sample_field", "sample", "bilinear", "value"),
+    ("point_sample_field", "sample", "bicubic", "value"),
+    ("point_sample_field", "sample", "lanczos", "value"),
 }
 
 

--- a/raster2dggs/indexers/dggalrasterindexer.py
+++ b/raster2dggs/indexers/dggalrasterindexer.py
@@ -123,7 +123,7 @@ class DGGALRasterIndexer(RasterIndexer):
         Override: always return exactly one parent per cell.
 
         For 3H grids, parent_cells() returns all ancestors (up to 3^depth per
-        cell) to support compaction. For partitioning in sample_nn we only need
+        cell) to support compaction. For partitioning in --transfer sample we only need
         one representative parent — the centroid-parent path, which is what
         _get_ancestor already uses for all DGGAL grids.
         """

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -246,7 +246,7 @@ class RasterIndexer(IRasterIndexer):
         decimals: Optional[int] = None,
     ) -> pd.DataFrame:
         """
-        For sample_nn transfer: deduplicate cells that appear in more than one
+        For --transfer sample: deduplicate cells that appear in more than one
         window partition. Because each cell's sample pixel belongs to exactly one
         window, all duplicates carry identical values; .first() is sufficient.
         Applies the same decimals rounding/casting as parent_groupby.
@@ -268,10 +268,6 @@ class RasterIndexer(IRasterIndexer):
         gb.index.name = index_col
         return gb
 
-    # ------------------------------------------------------------------ #
-    # Cell enumeration (required for sample_nn)                           #
-    # ------------------------------------------------------------------ #
-
     #: Set to True in subclasses that implement cells_in_bbox.
     SUPPORTS_CELL_ENUMERATION: bool = False
 
@@ -290,7 +286,7 @@ class RasterIndexer(IRasterIndexer):
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not support spatial cell enumeration. "
-            "sample_nn requires cell enumeration; use a DGGS that supports it."
+            "--transfer sample requires cell enumeration; use a DGGS that supports it."
         )
 
     def _collect_lists(

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Any, Callable, List, Tuple, Union, Optional
+from typing import Callable, List, Tuple, Union, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -218,12 +218,16 @@ class RasterIndexer(IRasterIndexer):
                 ).agg(func)
                 if decimals is not None:
                     if decimals > 0:
-                        to_promote = r.select_dtypes(include=["float32", "integer"]).columns
+                        to_promote = r.select_dtypes(
+                            include=["float32", "integer"]
+                        ).columns
                         if len(to_promote):
                             r = r.astype({c: "float64" for c in to_promote})
                     r = r.round(decimals)
                     if decimals <= 0:
-                        r = r.astype({c: "Int64" for c in r.columns if c != partition_col})
+                        r = r.astype(
+                            {c: "Int64" for c in r.columns if c != partition_col}
+                        )
                 per_agg[agg_name] = r.reset_index(level=0)
 
             base = next(iter(per_agg.values()))

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -96,7 +96,7 @@ class IRasterIndexer:
         decimals: Optional[int] = None,
     ) -> pd.DataFrame:
         """
-        For sample_nn transfer: deduplicate cells that appear in more than one
+        For --transfer sample: deduplicate cells that appear in more than one
         window partition. Applies decimals rounding/casting when provided.
         """
         raise NotImplementedError

--- a/raster2dggs/interpolation.py
+++ b/raster2dggs/interpolation.py
@@ -1,0 +1,529 @@
+"""
+Raster sampling context for --transfer sample.
+
+_SampleIndexer holds all shared state (open raster, transformer, indexer
+config) and exposes process_nn / process_bilinear / process_bicubic /
+process_lanczos as bound methods.  Each method accepts only a rasterio
+Window and returns None, making them drop-in callables for
+ThreadPoolExecutor.map.
+
+Keeping the sampling logic here (rather than as closures inside
+initial_index) makes the methods independently unit-testable and keeps
+common.py focused on orchestration.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, Optional
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyproj
+import rasterio as rio
+import xarray as xr
+from rasterio.warp import transform_bounds
+
+from raster2dggs.indexers.rasterindexer import _is_nan
+from raster2dggs.interfaces import IRasterIndexer
+
+_BICUBIC_OFFSETS = np.array([-1, 0, 1, 2], dtype=float)
+_BICUBIC_OFFSETS_INT = np.array([-1, 0, 1, 2], dtype=int)
+
+
+def _bicubic_kernel(t: np.ndarray, a: float = -0.5) -> np.ndarray:
+    """Keys cubic convolution kernel.
+
+    a = -0.5 (default, Keys 1989): best approximation to sinc.
+    a = -0.75: produces slightly more ringing but commonly used in image
+    processing libraries (e.g. OpenCV).
+
+    |t| ≤ 1: (a+2)|t|³ − (a+3)|t|² + 1
+    1 < |t| ≤ 2: a|t|³ − 5a|t|² + 8a|t| − 4a
+    """
+    t = np.abs(t)
+    return np.where(
+        t <= 1,
+        (a + 2) * t**3 - (a + 3) * t**2 + 1,
+        np.where(t <= 2, a * t**3 - 5 * a * t**2 + 8 * a * t - 4 * a, 0.0),
+    )
+
+
+def _lanczos_kernel(t: np.ndarray, a: int = 3) -> np.ndarray:
+    """Lanczos resampling kernel with `a` lobes (default: 3, giving a 6×6 stencil).
+
+    L(t) = sinc(t) · sinc(t/a)   for |t| < a
+    L(t) = 0                      for |t| ≥ a
+    where sinc(x) = sin(πx) / (πx), L(0) = 1.
+    """
+    t = np.abs(t)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = np.where(
+            t == 0,
+            1.0,
+            np.where(
+                t < a,
+                a * np.sin(np.pi * t) * np.sin(np.pi * t / a) / (np.pi**2 * t**2),
+                0.0,
+            ),
+        )
+    return result
+
+
+@dataclasses.dataclass(repr=False)
+class _SampleIndexer:
+    """Shared context for all --transfer sample process methods.
+
+    Instantiate once per raster open; pass bound methods (e.g.
+    ctx.process_bicubic) to ThreadPoolExecutor.map.
+    """
+
+    src: rio.DatasetReader
+    da: xr.DataArray
+    inverse_transformer: pyproj.Transformer
+    nodata: Any
+    indexer: IRasterIndexer
+    resolution: int
+    parent_res: int
+    selected_labels: tuple
+    nodata_policy: str
+    emit_nodata_value: Optional[Any]
+    write_result: Callable
+    # Kernel tuning parameters — use field(default=…) so the dataclass
+    # keeps all non-default fields before these.
+    bicubic_a: float = dataclasses.field(default=-0.5)
+    lanczos_lobes: int = dataclasses.field(default=3)
+
+    def __post_init__(self):
+        lobe = self.lanczos_lobes
+        self._lanczos_ns: int = 2 * lobe
+        self._lanczos_offsets_int: np.ndarray = np.arange(
+            -(lobe - 1), lobe + 1, dtype=int
+        )
+        self._lanczos_offsets_float: np.ndarray = self._lanczos_offsets_int.astype(
+            float
+        )
+
+    def _enumerate_cells(self, window):
+        """Return (cells, frac_rows, frac_cols) for all DGGS cells whose
+        centres fall within the window's geographic bbox.
+
+        frac_rows / frac_cols are fractional pixel-centre coordinates in
+        raster space: (0.0, 0.0) is the centre of the top-left pixel.
+
+        Returns (None, None, None) if no cells qualify.
+        """
+        win_left, win_bottom, win_right, win_top = self.src.window_bounds(window)
+        min_lon, min_lat, max_lon, max_lat = transform_bounds(
+            self.src.crs, "EPSG:4326", win_left, win_bottom, win_right, win_top
+        )
+        cells = list(
+            self.indexer.cells_in_bbox(
+                min_lon, min_lat, max_lon, max_lat, self.resolution
+            )
+        )
+        if not cells:
+            return None, None, None
+
+        cell_lons, cell_lats = self.indexer.cells_to_lonlat_arrays(pd.Series(cells))
+        # Pass as Python lists to avoid pyproj trying float(array) on
+        # 1-element numpy arrays, triggering a NumPy DeprecationWarning.
+        _xs, _ys = self.inverse_transformer.transform(
+            cell_lons.tolist(), cell_lats.tolist()
+        )
+        cell_xs = np.asarray(_xs)
+        cell_ys = np.asarray(_ys)
+
+        # ~transform maps (x, y) → (col_ul, row_ul) in the UL-corner pixel
+        # system; subtract 0.5 to get pixel-centre coords where (0.0, 0.0)
+        # is the centre of the top-left pixel.
+        inv = ~self.src.transform
+        frac_cols = inv.a * cell_xs + inv.b * cell_ys + inv.c - 0.5
+        frac_rows = inv.d * cell_xs + inv.e * cell_ys + inv.f - 0.5
+
+        return cells, frac_rows, frac_cols
+
+    def _expand_window(self, window, margin: int):
+        """Expand window by margin pixels, clamped to raster bounds."""
+        row_off = max(0, window.row_off - margin)
+        col_off = max(0, window.col_off - margin)
+        row_end = min(self.src.height, window.row_off + window.height + margin)
+        col_end = min(self.src.width, window.col_off + window.width + margin)
+        return rio.windows.Window(
+            col_off, row_off, col_end - col_off, row_end - row_off
+        )
+
+    def _build_and_write(self, cells, samples, nd_mask, window):
+        """Build the output DataFrame and write to the stage-1 store.
+
+        samples is (n_cells, n_bands) float with NaN where nodata.
+        nd_mask is a bool array of length n_cells.
+        """
+        wide = pd.DataFrame(
+            {label: samples[:, i] for i, label in enumerate(self.selected_labels)}
+        )
+        index_col = self.indexer.index_col(self.resolution)
+        partition_col = self.indexer.partition_col(self.parent_res)
+        wide[index_col] = cells
+        wide[partition_col] = list(
+            self.indexer.single_parent_cells(cells, self.parent_res)
+        )
+        if self.nodata_policy.lower() == "omit":
+            wide = wide[~nd_mask].reset_index(drop=True)
+        elif self.nodata_policy.lower() == "emit":
+            fill = (
+                self.emit_nodata_value
+                if self.emit_nodata_value is not None
+                else self.nodata
+            )
+            for label in self.selected_labels:
+                if pd.isna(fill):
+                    wide.loc[nd_mask, label] = np.nan
+                else:
+                    wide.loc[nd_mask, label] = fill
+        if wide.empty:
+            return None
+        result = pa.Table.from_pandas(wide, preserve_index=False)
+        self.write_result(result, window)
+        return None
+
+    def process_nn(self, window):
+        """Nearest-neighbour sample: assign each DGGS cell the value of the
+        closest raster pixel (floor(frac + 0.5) in pixel-centre coordinates).
+        """
+        cells, frac_rows, frac_cols = self._enumerate_cells(window)
+        if cells is None:
+            return None
+
+        # Nearest pixel: floor(frac + 0.5) matches rasterio's rowcol default.
+        nn_rows = np.floor(frac_rows + 0.5).astype(int)
+        nn_cols = np.floor(frac_cols + 0.5).astype(int)
+        local_rows = nn_rows - window.row_off
+        local_cols = nn_cols - window.col_off
+        in_win = (
+            (local_rows >= 0)
+            & (local_rows < window.height)
+            & (local_cols >= 0)
+            & (local_cols < window.width)
+        )
+        if not np.any(in_win):
+            return None
+
+        cells = [c for c, m in zip(cells, in_win) if m]
+        local_rows = local_rows[in_win]
+        local_cols = local_cols[in_win]
+
+        win_data = self.da.rio.isel_window(window).values  # (bands, H, W)
+        samples = win_data[:, local_rows, local_cols].T.astype(float)
+        if self.nodata is not None and not _is_nan(self.nodata):
+            samples[samples == self.nodata] = np.nan
+        nd_mask = np.any(np.isnan(samples), axis=1)
+
+        return self._build_and_write(cells, samples, nd_mask, window)
+
+    def process_bilinear(self, window):
+        """Bilinear sample: weighted average of the 2×2 pixel neighbourhood
+        surrounding each DGGS cell centre.
+
+        Renormalises weights over valid (non-nodata, in-bounds) corners; a
+        cell is emitted as nodata only when fewer than 2 of its 4 corners are
+        valid.  Window assignment uses the nearest-pixel rule (same as NN) to
+        avoid a half-pixel-wide strip of dropped cells at window boundaries.
+        """
+        cells, frac_rows, frac_cols = self._enumerate_cells(window)
+        if cells is None:
+            return None
+
+        # Assign cells by nearest pixel — same rule as NN — so the
+        # assignment exactly matches what cells_in_bbox discovers and
+        # no cells fall through window-boundary gaps.
+        # (Using floor-pixel assignment instead causes a half-pixel-
+        # wide strip of dropped cells at every window boundary because
+        # cells with frac ∈ (row_off+height−0.5, row_off+height) have
+        # their WGS84 centre in the next window's bbox but their floor
+        # pixel still in this window.)
+        nn_rows = np.floor(frac_rows + 0.5).astype(int)
+        nn_cols = np.floor(frac_cols + 0.5).astype(int)
+        local_nn_rows = nn_rows - window.row_off
+        local_nn_cols = nn_cols - window.col_off
+        in_win = (
+            (local_nn_rows >= 0)
+            & (local_nn_rows < window.height)
+            & (local_nn_cols >= 0)
+            & (local_nn_cols < window.width)
+        )
+        if not np.any(in_win):
+            return None
+
+        cells = [c for c, m in zip(cells, in_win) if m]
+        frac_rows = frac_rows[in_win]
+        frac_cols = frac_cols[in_win]
+
+        floor_rows = np.floor(frac_rows).astype(int)
+        floor_cols = np.floor(frac_cols).astype(int)
+        dr = frac_rows - floor_rows  # fractional row offset [0, 1)
+        dc = frac_cols - floor_cols  # fractional col offset [0, 1)
+
+        # Read with 1-pixel margin so the bilinear stencil is always
+        # available, even when the floor pixel is in the adjacent window
+        # (cells with frac ∈ [nn−0.5, nn) have floor = nn−1).
+        exp = self._expand_window(window, margin=1)
+        win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        exp_h, exp_w = win_data.shape[1], win_data.shape[2]
+
+        r0_raw = floor_rows - exp.row_off
+        c0_raw = floor_cols - exp.col_off
+        r1_raw = r0_raw + 1
+        c1_raw = c0_raw + 1
+
+        # Stencil extends outside the raster — emit nodata rather than
+        # inventing values by repeating the edge.
+        outside_raster = (
+            (r0_raw < 0) | (r1_raw >= exp_h) | (c0_raw < 0) | (c1_raw >= exp_w)
+        )
+
+        r0 = np.clip(r0_raw, 0, exp_h - 1)
+        c0 = np.clip(c0_raw, 0, exp_w - 1)
+        r1 = np.clip(r1_raw, 0, exp_h - 1)
+        c1 = np.clip(c1_raw, 0, exp_w - 1)
+
+        dr = dr[:, np.newaxis]  # (n_cells, 1) for broadcasting
+        dc = dc[:, np.newaxis]
+
+        has_nodata = self.nodata is not None and not _is_nan(self.nodata)
+
+        def _corner(rows, cols):
+            s = win_data[:, rows, cols].T.astype(float)  # (n_cells, bands)
+            if has_nodata:
+                s[s == self.nodata] = np.nan
+            return s
+
+        f00 = _corner(r0, c0)
+        f01 = _corner(r0, c1)
+        f10 = _corner(r1, c0)
+        f11 = _corner(r1, c1)
+
+        # Fast path: no OOB and all corners valid.
+        if not np.any(outside_raster) and not (
+            np.any(np.isnan(f00))
+            or np.any(np.isnan(f01))
+            or np.any(np.isnan(f10))
+            or np.any(np.isnan(f11))
+        ):
+            samples = (
+                (1 - dr) * (1 - dc) * f00
+                + (1 - dr) * dc * f01
+                + dr * (1 - dc) * f10
+                + dr * dc * f11
+            )
+            return self._build_and_write(
+                cells, samples, np.zeros(len(cells), dtype=bool), window
+            )
+
+        # Slow path: mark OOB corners as NaN so renormalization handles
+        # them uniformly (valid_count < 2 catches cells with no good data).
+        f00[outside_raster] = np.nan
+        f01[outside_raster] = np.nan
+        f10[outside_raster] = np.nan
+        f11[outside_raster] = np.nan
+
+        # Renormalise weights over valid (non-NaN) corners; require ≥ 2.
+        nan00 = np.isnan(f00)
+        nan01 = np.isnan(f01)
+        nan10 = np.isnan(f10)
+        nan11 = np.isnan(f11)
+        valid_count = (
+            (~nan00).astype(int)
+            + (~nan01).astype(int)
+            + (~nan10).astype(int)
+            + (~nan11).astype(int)
+        )  # (n_cells, bands)
+        w00 = np.where(nan00, 0.0, (1 - dr) * (1 - dc))
+        w01 = np.where(nan01, 0.0, (1 - dr) * dc)
+        w10 = np.where(nan10, 0.0, dr * (1 - dc))
+        w11 = np.where(nan11, 0.0, dr * dc)
+        f00 = np.where(nan00, 0.0, f00)
+        f01 = np.where(nan01, 0.0, f01)
+        f10 = np.where(nan10, 0.0, f10)
+        f11 = np.where(nan11, 0.0, f11)
+        total_w = w00 + w01 + w10 + w11  # (n_cells, bands)
+        with np.errstate(invalid="ignore"):  # 0/0 → NaN is intentional
+            samples = (w00 * f00 + w01 * f01 + w10 * f10 + w11 * f11) / total_w
+        nd_mask = (valid_count < 2).any(axis=1)
+
+        return self._build_and_write(cells, samples, nd_mask, window)
+
+    def process_bicubic(self, window):
+        """Bicubic (Keys cubic convolution) sample: 4×4 pixel stencil.
+
+        Uses the Keys 1989 piecewise-cubic kernel with shape parameter
+        `self.bicubic_a` (default -0.5, which best approximates a sinc;
+        -0.75 matches OpenCV/PIL and produces slightly more ringing).
+
+        Renormalises weights over valid pixels; a cell is emitted as nodata
+        when fewer than 4 of its 16 stencil pixels are valid.
+        """
+        cells, frac_rows, frac_cols = self._enumerate_cells(window)
+        if cells is None:
+            return None
+
+        nn_rows = np.floor(frac_rows + 0.5).astype(int)
+        nn_cols = np.floor(frac_cols + 0.5).astype(int)
+        local_nn_rows = nn_rows - window.row_off
+        local_nn_cols = nn_cols - window.col_off
+        in_win = (
+            (local_nn_rows >= 0)
+            & (local_nn_rows < window.height)
+            & (local_nn_cols >= 0)
+            & (local_nn_cols < window.width)
+        )
+        if not np.any(in_win):
+            return None
+
+        cells = [c for c, m in zip(cells, in_win) if m]
+        frac_rows = frac_rows[in_win]
+        frac_cols = frac_cols[in_win]
+
+        floor_rows = np.floor(frac_rows).astype(int)
+        floor_cols = np.floor(frac_cols).astype(int)
+        dr = frac_rows - floor_rows
+        dc = frac_cols - floor_cols
+
+        exp = self._expand_window(window, margin=2)
+        win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        exp_h, exp_w = win_data.shape[1], win_data.shape[2]
+        n = len(cells)
+        bands = win_data.shape[0]
+
+        # 4×4 stencil: offsets [-1, 0, 1, 2] from floor pixel
+        local_r = floor_rows[:, np.newaxis] + _BICUBIC_OFFSETS_INT - exp.row_off
+        local_c = floor_cols[:, np.newaxis] + _BICUBIC_OFFSETS_INT - exp.col_off
+        r_bcast = np.broadcast_to(local_r[:, :, np.newaxis], (n, 4, 4))
+        c_bcast = np.broadcast_to(local_c[:, np.newaxis, :], (n, 4, 4))
+        oob = (r_bcast < 0) | (r_bcast >= exp_h) | (c_bcast < 0) | (c_bcast >= exp_w)
+        r_safe = np.clip(r_bcast, 0, exp_h - 1)
+        c_safe = np.clip(c_bcast, 0, exp_w - 1)
+
+        gathered = win_data[:, r_safe.reshape(-1), c_safe.reshape(-1)]
+        pixel_values = (
+            gathered.reshape(bands, n, 4, 4).transpose(1, 2, 3, 0).astype(float)
+        )  # (n, 4, 4, bands)
+
+        if self.nodata is not None and not _is_nan(self.nodata):
+            pixel_values[pixel_values == self.nodata] = np.nan
+
+        row_t = np.abs(dr[:, np.newaxis] - _BICUBIC_OFFSETS)  # (n, 4)
+        col_t = np.abs(dc[:, np.newaxis] - _BICUBIC_OFFSETS)  # (n, 4)
+        row_w = _bicubic_kernel(row_t, a=self.bicubic_a)  # (n, 4)
+        col_w = _bicubic_kernel(col_t, a=self.bicubic_a)  # (n, 4)
+        weights_2d = row_w[:, :, np.newaxis] * col_w[:, np.newaxis, :]  # (n, 4, 4)
+
+        # Fast path: all stencil pixels in-bounds and non-nodata.
+        if not np.any(oob) and not np.any(np.isnan(pixel_values)):
+            samples = (weights_2d[:, :, :, np.newaxis] * pixel_values).sum(axis=(1, 2))
+            return self._build_and_write(
+                cells, samples, np.zeros(n, dtype=bool), window
+            )
+
+        # Slow path: renormalise over valid pixels; require ≥ 4 per band.
+        pixel_values[oob] = np.nan
+        nan_mask = np.isnan(pixel_values)  # (n, 4, 4, bands)
+        valid_count = (~nan_mask).sum(axis=(1, 2))  # (n, bands)
+        masked_w = np.where(nan_mask, 0.0, weights_2d[:, :, :, np.newaxis])
+        pixel_values_safe = np.where(nan_mask, 0.0, pixel_values)
+        total_w = masked_w.sum(axis=(1, 2))  # (n, bands)
+        with np.errstate(invalid="ignore"):
+            samples = (masked_w * pixel_values_safe).sum(axis=(1, 2)) / total_w
+        nd_mask = (valid_count < 4).any(axis=1)
+
+        return self._build_and_write(cells, samples, nd_mask, window)
+
+    def process_lanczos(self, window):
+        """Lanczos windowed-sinc sample: (2·lobes)×(2·lobes) pixel stencil.
+
+        Uses `self.lanczos_lobes` (default 3, giving a 6×6 stencil) to
+        control quality vs. cost.  The kernel is L(t) = sinc(t)·sinc(t/a)
+        for |t| < a, zero elsewhere (Lanczos-3 by default).
+
+        Renormalises weights over valid pixels; a cell is emitted as nodata
+        when fewer than 4 of its stencil pixels are valid.
+        """
+        cells, frac_rows, frac_cols = self._enumerate_cells(window)
+        if cells is None:
+            return None
+
+        nn_rows = np.floor(frac_rows + 0.5).astype(int)
+        nn_cols = np.floor(frac_cols + 0.5).astype(int)
+        local_nn_rows = nn_rows - window.row_off
+        local_nn_cols = nn_cols - window.col_off
+        in_win = (
+            (local_nn_rows >= 0)
+            & (local_nn_rows < window.height)
+            & (local_nn_cols >= 0)
+            & (local_nn_cols < window.width)
+        )
+        if not np.any(in_win):
+            return None
+
+        cells = [c for c, m in zip(cells, in_win) if m]
+        frac_rows = frac_rows[in_win]
+        frac_cols = frac_cols[in_win]
+
+        floor_rows = np.floor(frac_rows).astype(int)
+        floor_cols = np.floor(frac_cols).astype(int)
+        dr = frac_rows - floor_rows
+        dc = frac_cols - floor_cols
+
+        lobe = self.lanczos_lobes
+        ns = self._lanczos_ns
+        offsets_int = self._lanczos_offsets_int
+        offsets_float = self._lanczos_offsets_float
+
+        exp = self._expand_window(window, margin=lobe)
+        win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        exp_h, exp_w = win_data.shape[1], win_data.shape[2]
+        n = len(cells)
+        bands = win_data.shape[0]
+
+        local_r = floor_rows[:, np.newaxis] + offsets_int - exp.row_off
+        local_c = floor_cols[:, np.newaxis] + offsets_int - exp.col_off
+        r_bcast = np.broadcast_to(local_r[:, :, np.newaxis], (n, ns, ns))
+        c_bcast = np.broadcast_to(local_c[:, np.newaxis, :], (n, ns, ns))
+        oob = (r_bcast < 0) | (r_bcast >= exp_h) | (c_bcast < 0) | (c_bcast >= exp_w)
+        r_safe = np.clip(r_bcast, 0, exp_h - 1)
+        c_safe = np.clip(c_bcast, 0, exp_w - 1)
+
+        gathered = win_data[:, r_safe.reshape(-1), c_safe.reshape(-1)]
+        pixel_values = (
+            gathered.reshape(bands, n, ns, ns).transpose(1, 2, 3, 0).astype(float)
+        )  # (n, ns, ns, bands)
+
+        if self.nodata is not None and not _is_nan(self.nodata):
+            pixel_values[pixel_values == self.nodata] = np.nan
+
+        row_t = np.abs(dr[:, np.newaxis] - offsets_float)  # (n, ns)
+        col_t = np.abs(dc[:, np.newaxis] - offsets_float)  # (n, ns)
+        row_w = _lanczos_kernel(row_t, a=lobe)  # (n, ns)
+        col_w = _lanczos_kernel(col_t, a=lobe)  # (n, ns)
+        weights_2d = row_w[:, :, np.newaxis] * col_w[:, np.newaxis, :]  # (n, ns, ns)
+
+        # Fast path: all stencil pixels in-bounds and non-nodata.
+        if not np.any(oob) and not np.any(np.isnan(pixel_values)):
+            samples = (weights_2d[:, :, :, np.newaxis] * pixel_values).sum(axis=(1, 2))
+            return self._build_and_write(
+                cells, samples, np.zeros(n, dtype=bool), window
+            )
+
+        # Slow path: renormalise over valid pixels; require ≥ 4 per band.
+        pixel_values[oob] = np.nan
+        nan_mask = np.isnan(pixel_values)  # (n, ns, ns, bands)
+        valid_count = (~nan_mask).sum(axis=(1, 2))  # (n, bands)
+        masked_w = np.where(nan_mask, 0.0, weights_2d[:, :, :, np.newaxis])
+        pixel_values_safe = np.where(nan_mask, 0.0, pixel_values)
+        total_w = masked_w.sum(axis=(1, 2))  # (n, bands)
+        with np.errstate(invalid="ignore"):
+            samples = (masked_w * pixel_values_safe).sum(axis=(1, 2)) / total_w
+        nd_mask = (valid_count < 4).any(axis=1)
+
+        return self._build_and_write(cells, samples, nd_mask, window)

--- a/tests/classes/test_output_schema.py
+++ b/tests/classes/test_output_schema.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pyarrow as pa
-import pyarrow.parquet as pq
-import pandas as pd
 from click.testing import CliRunner
 
 from classes.base import TestRunthrough, read_output
@@ -416,18 +414,156 @@ class TestOutListValidation(TestRunthrough):
 
     def test_sample_point_sample_field_runs(self):
         self.invoke_cli(
-            "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
-            "--semantics", "point_sample_field",
-            "--transfer", "sample",
-            "--out", "value",
+            "h3",
+            self._raster,
+            TEST_OUTPUT_PATH,
+            _COARSE_RES,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--out",
+            "value",
         )
 
     def test_sample_piecewise_constant_runs(self):
         self.invoke_cli(
-            "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
-            "--semantics", "piecewise_constant",
-            "--transfer", "sample",
-            "--out", "value",
+            "h3",
+            self._raster,
+            TEST_OUTPUT_PATH,
+            _COARSE_RES,
+            "--semantics",
+            "piecewise_constant",
+            "--transfer",
+            "sample",
+            "--out",
+            "value",
+        )
+
+    def test_sample_bilinear_point_sample_field_runs(self):
+        self.invoke_cli(
+            "h3",
+            self._raster,
+            TEST_OUTPUT_PATH,
+            _COARSE_RES,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "bilinear",
+            "--out",
+            "value",
+        )
+
+    def test_sample_bilinear_piecewise_constant_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "h3",
+                self._raster,
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_COARSE_RES),
+                "--semantics",
+                "piecewise_constant",
+                "--transfer",
+                "sample",
+                "--interp",
+                "bilinear",
+                "--out",
+                "value",
+            ],
+        )
+        self.assertNotEqual(
+            result.exit_code,
+            0,
+            "piecewise_constant + bilinear should be rejected",
+        )
+
+    def test_sample_bicubic_point_sample_field_runs(self):
+        self.invoke_cli(
+            "h3",
+            self._raster,
+            TEST_OUTPUT_PATH,
+            _COARSE_RES,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "bicubic",
+            "--out",
+            "value",
+        )
+
+    def test_sample_bicubic_piecewise_constant_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "h3",
+                self._raster,
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_COARSE_RES),
+                "--semantics",
+                "piecewise_constant",
+                "--transfer",
+                "sample",
+                "--interp",
+                "bicubic",
+                "--out",
+                "value",
+            ],
+        )
+        self.assertNotEqual(
+            result.exit_code,
+            0,
+            "piecewise_constant + bicubic should be rejected",
+        )
+
+    def test_sample_lanczos_point_sample_field_runs(self):
+        self.invoke_cli(
+            "h3",
+            self._raster,
+            TEST_OUTPUT_PATH,
+            _COARSE_RES,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "lanczos",
+            "--out",
+            "value",
+        )
+
+    def test_sample_lanczos_piecewise_constant_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "h3",
+                self._raster,
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_COARSE_RES),
+                "--semantics",
+                "piecewise_constant",
+                "--transfer",
+                "sample",
+                "--interp",
+                "lanczos",
+                "--out",
+                "value",
+            ],
+        )
+        self.assertNotEqual(
+            result.exit_code,
+            0,
+            "piecewise_constant + lanczos should be rejected",
         )
 
 

--- a/tests/classes/test_output_schema.py
+++ b/tests/classes/test_output_schema.py
@@ -401,9 +401,9 @@ class TestOutListValidation(TestRunthrough):
                 "-r",
                 str(_COARSE_RES),
                 "--semantics",
-                "point_sample_field",
+                "density",
                 "--transfer",
-                "sample_interp",
+                "sample",
                 "--out",
                 "value",
             ],
@@ -411,22 +411,22 @@ class TestOutListValidation(TestRunthrough):
         self.assertNotEqual(
             result.exit_code,
             0,
-            "point_sample_field + sample_interp is valid but not yet implemented",
+            "density + sample is valid but not yet implemented",
         )
 
-    def test_sample_nn_point_sample_field_runs(self):
+    def test_sample_point_sample_field_runs(self):
         self.invoke_cli(
             "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
             "--semantics", "point_sample_field",
-            "--transfer", "sample_nn",
+            "--transfer", "sample",
             "--out", "value",
         )
 
-    def test_sample_nn_piecewise_constant_runs(self):
+    def test_sample_piecewise_constant_runs(self):
         self.invoke_cli(
             "h3", self._raster, TEST_OUTPUT_PATH, _COARSE_RES,
             "--semantics", "piecewise_constant",
-            "--transfer", "sample_nn",
+            "--transfer", "sample",
             "--out", "value",
         )
 

--- a/tests/classes/test_sample.py
+++ b/tests/classes/test_sample.py
@@ -179,3 +179,105 @@ class TestHEALPixSample(_SampleSmoke, unittest.TestCase):
     dggs = "healpix"
     resolution = 8
     extra = "dggal"
+
+
+class _SampleBilinearSmoke(_SampleSmoke):
+    """
+    Base class for --transfer sample --interp bilinear smoke tests.
+
+    Inherits all _SampleSmoke tests; overrides _run to add --interp bilinear.
+    Because the raster is uniform, bilinear and NN produce identical values,
+    so the same value assertions apply.
+    """
+
+    def _run(self, *extra_args):
+        return self.invoke_cli(
+            self.dggs,
+            self._raster,
+            TEST_OUTPUT_PATH,
+            self.resolution,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "bilinear",
+            "--out",
+            "value",
+            *extra_args,
+        )
+
+
+class TestH3SampleBilinear(_SampleBilinearSmoke, unittest.TestCase):
+    # Bilinear is implemented in common.py, not per-DGGS; one representative is enough.
+    dggs = "h3"
+    resolution = 5
+    extra = "h3"
+
+
+class _SampleBicubicSmoke(_SampleSmoke):
+    """
+    Base class for --transfer sample --interp cubic smoke tests.
+
+    Inherits all _SampleSmoke tests; overrides _run to add --interp cubic.
+    Because the raster is uniform, cubic and NN produce identical values,
+    so the same value assertions apply.
+    """
+
+    def _run(self, *extra_args):
+        return self.invoke_cli(
+            self.dggs,
+            self._raster,
+            TEST_OUTPUT_PATH,
+            self.resolution,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "bicubic",
+            "--out",
+            "value",
+            *extra_args,
+        )
+
+
+class TestH3SampleBicubic(_SampleBicubicSmoke, unittest.TestCase):
+    # Bicubic is implemented in common.py, not per-DGGS; one representative is enough.
+    dggs = "h3"
+    resolution = 5
+    extra = "h3"
+
+
+class _SampleLanczosSmoke(_SampleSmoke):
+    """
+    Base class for --transfer sample --interp lanczos smoke tests.
+
+    Inherits all _SampleSmoke tests; overrides _run to add --interp lanczos.
+    Because the raster is uniform, Lanczos and NN produce identical values,
+    so the same value assertions apply.
+    """
+
+    def _run(self, *extra_args):
+        return self.invoke_cli(
+            self.dggs,
+            self._raster,
+            TEST_OUTPUT_PATH,
+            self.resolution,
+            "--semantics",
+            "point_sample_field",
+            "--transfer",
+            "sample",
+            "--interp",
+            "lanczos",
+            "--out",
+            "value",
+            *extra_args,
+        )
+
+
+class TestH3SampleLanczos(_SampleLanczosSmoke, unittest.TestCase):
+    # Lanczos is implemented in common.py, not per-DGGS; one representative is enough.
+    dggs = "h3"
+    resolution = 5
+    extra = "h3"

--- a/tests/classes/test_sample_nn.py
+++ b/tests/classes/test_sample_nn.py
@@ -1,5 +1,5 @@
 """
-CLI smoke tests for --transfer sample_nn across all DGGS implementations.
+CLI smoke tests for --transfer sample across all DGGS implementations.
 
 Each DGGS has a different cells_in_bbox / cells_to_lonlat_arrays
 implementation. These end-to-end tests verify the full pipeline produces valid
@@ -31,9 +31,9 @@ def _make_raster(path: str) -> None:
     make_raster(path, _BOUNDS, _SIZE, pixel_value=_PIXEL_VALUE)
 
 
-class _SampleNNSmoke(TestRunthrough):
+class _SampleSmoke(TestRunthrough):
     """
-    Base class for per-DGGS sample_nn smoke tests.
+    Base class for per-DGGS --transfer sample smoke tests.
 
     Subclasses set:
       dggs       — CLI subcommand name (e.g. "h3")
@@ -60,7 +60,7 @@ class _SampleNNSmoke(TestRunthrough):
             "--semantics",
             "point_sample_field",
             "--transfer",
-            "sample_nn",
+            "sample",
             "--out",
             "value",
             *extra_args,
@@ -74,7 +74,7 @@ class _SampleNNSmoke(TestRunthrough):
         result = self._run()
         self.assertEqual(result.exit_code, 0, result.output)
         table = pq.read_table(str(TEST_OUTPUT_PATH))
-        self.assertGreater(len(table), 0, "sample_nn produced no output rows")
+        self.assertGreater(len(table), 0, "--transfer sample produced no output rows")
 
     def test_output_values_match_pixel(self):
         result = self._run()
@@ -87,52 +87,52 @@ class _SampleNNSmoke(TestRunthrough):
             f"Expected all values ≈ {_PIXEL_VALUE}, got: {vals.unique()}",
         )
 
-    def test_agg_warning_emitted_for_sample_nn(self):
+    def test_agg_warning_emitted_for_sample(self):
         result = self._run("--agg", "sum")
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn(
             "--agg",
             result.output,
-            "--agg warning should be emitted when combined with --transfer sample_nn",
+            "--agg warning should be emitted when combined with --transfer sample",
         )
 
 
-class TestH3SampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestH3Sample(_SampleSmoke, unittest.TestCase):
     # res 5: ~252 km² cells → ~28 cells in a 1° × 1° bbox
     dggs = "h3"
     resolution = 5
     extra = "h3"
 
 
-class TestRHPSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestRHPSample(_SampleSmoke, unittest.TestCase):
     # res 6: ~1440 km² cells → ~5 cells in a 1° × 1° bbox
     dggs = "rhp"
     resolution = 6
     extra = "rhp"
 
 
-class TestGeohashSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestGeohashSample(_SampleSmoke, unittest.TestCase):
     # precision 4: lon_step ≈ 0.35°, lat_step ≈ 0.18° → ~16 cells
     dggs = "geohash"
     resolution = 4
     extra = "geohash"
 
 
-class TestMaidenheadSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestMaidenheadSample(_SampleSmoke, unittest.TestCase):
     # level 3: lon_step ≈ 0.083°, lat_step ≈ 0.042° → ~288 cells
     dggs = "maidenhead"
     resolution = 3
     extra = "maidenhead"
 
 
-class TestS2SampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestS2Sample(_SampleSmoke, unittest.TestCase):
     # level 8: ~1300 km² cells → ~5 cells in a 1° × 1° bbox
     dggs = "s2"
     resolution = 8
     extra = "s2"
 
 
-class TestA5SampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestA5Sample(_SampleSmoke, unittest.TestCase):
     # level 8: ~649 km² cells → ~11 cells in a 1° × 1° bbox
     dggs = "a5"
     resolution = 8
@@ -145,14 +145,14 @@ class TestA5SampleNN(_SampleNNSmoke, unittest.TestCase):
 # catch any family-specific issues (refinement ratio, coordinate handling, etc.)
 
 
-class TestISEA4RSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestISEA4RSample(_SampleSmoke, unittest.TestCase):
     # level 8: ~1300 km² cells → ~5 cells in a 1° × 1° bbox
     dggs = "isea4r"
     resolution = 8
     extra = "dggal"
 
 
-class TestISEA9RSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestISEA9RSample(_SampleSmoke, unittest.TestCase):
     # level 5: 6 × 9^(5-1)?  No — ISEA9R is a 9R grid; pick a level that gives ~5-10 cells.
     # At level 5: ~5 cells based on empirical testing.
     dggs = "isea9r"
@@ -160,21 +160,21 @@ class TestISEA9RSampleNN(_SampleNNSmoke, unittest.TestCase):
     extra = "dggal"
 
 
-class TestISEA3HSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestISEA3HSample(_SampleSmoke, unittest.TestCase):
     # Hexagonal 3H; level 9 needed for cells to be small enough to land in bbox.
     dggs = "isea3h"
     resolution = 9
     extra = "dggal"
 
 
-class TestISEA7HSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestISEA7HSample(_SampleSmoke, unittest.TestCase):
     # Hexagonal 7H; level 6 gives ~3-6 cells in a 1° × 1° bbox.
     dggs = "isea7h"
     resolution = 6
     extra = "dggal"
 
 
-class TestHEALPixSampleNN(_SampleNNSmoke, unittest.TestCase):
+class TestHEALPixSample(_SampleSmoke, unittest.TestCase):
     # HEALPix; level 8 gives ~15 cells in a 1° × 1° bbox (from earlier testing).
     dggs = "healpix"
     resolution = 8


### PR DESCRIPTION
Adds support for indexing with sample interpolation as: `--semantics point_sample_field --transfer sample --interp nn|bilinear|bicubic|lanczos`.

The implementation uses a dataclass to abstract the closure.

NB this is a breaking change to the API, formerly `--semantics point_sample_field --transfer sample_nn` did nearest neighbour interpolation, and `--interp` didn't exist.

Fulfills part of #50 and #17

Spot the difference...

<img width="4724" height="4724" alt="dggs-interp-low" src="https://github.com/user-attachments/assets/02cfc6f7-8739-4803-a373-77ad13587b1e" />
