### PR TITLE
Add numeric (binned) histograms, closes #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,21 @@ The threshold is applied **per band**: a cell may receive a valid value for one 
 
 `--point histogram` and `--overlay histogram` count *exact* pixel values by default — useful for categorical rasters (land cover classes, masks), but not meaningful for continuous data (elevation, temperature), where every pixel is likely to have a distinct value. Pass `--hist-bins` or `--hist-width` to bin continuous values into a proper numeric histogram instead:
 
-- `--hist-bins EDGE,EDGE[,...]` — explicit ascending bin edges, e.g. `--hist-bins 0,10,20,50`. Bins are half-open `[a, b)`; the last bin is closed (a value exactly equal to the final edge is included, not dropped). Values outside `[first_edge, last_edge]` are dropped — use `-inf`/`inf` as the first/last edge to catch everything. Output `values` are the *lower* edge of each populated bin (only non-empty bins are reported).
+- `--hist-bins EDGE,EDGE[,...]` — explicit ascending bin edges, e.g. `--hist-bins 0,10,20,50`. Bins are half-open `[a, b)`; the last bin is closed (a value exactly equal to the final edge is included, not dropped). Values outside `[first_edge, last_edge]` are dropped — use `-inf`/`inf` as the first/last edge to catch everything.
 - `--hist-width FLOAT` (with optional `--hist-origin FLOAT`, default `0.0`) — uniform-width bins `[origin + k·width, origin + (k+1)·width)`. Unlike explicit edges, this is unbounded — every finite value falls into some bin, so nothing is dropped.
 - `--hist-bins` and `--hist-width` are mutually exclusive.
 
-With no `--hist-bins`/`--hist-width`, behaviour is unchanged (exact-value counts).
+With binning active, each populated bin's own bounds are reported directly (as two parallel arrays, `left`/`right`) alongside its weight, rather than requiring you to already know the bin configuration to interpret a row. Every bin, in every band and every row of a given output, is half-open `[left, right)`, except the very last bin overall, which is also closed on the right — a fixed rule of the tool (matching `numpy.histogram`'s convention), not something that can vary bin-to-bin, so it isn't stored per bin.
+
+Only non-empty bins are reported, and a bin's position in the arrays isn't fixed — cell A might have `[20,50)` at index 0, cell B at index 3, cell C not at all. To pull out a specific bin's value (e.g. in a QGIS expression or a SQL query), search by value rather than by position, e.g. in QGIS:
+
+```
+with_variable('idx', array_find("band_1.left", 20),
+  CASE WHEN @idx >= 0 THEN array_get("band_1.area_share", @idx) ELSE 0 END
+)
+```
+
+(the `ELSE 0` handles a cell that had nothing in that bin at all, since it's sparse, not an error — and note the `@idx` references to the variable, not `'idx'`/`"idx"`: single quotes are a QGIS string literal, double quotes are a field reference, and neither is the same as `@idx`, the actual variable reference. If `with_variable` still doesn't resolve inside the `CASE` in your QGIS version/context, repeat the `array_find` call instead of relying on the variable: `CASE WHEN array_find("band_1.left", 20) >= 0 THEN array_get("band_1.area_share", array_find("band_1.left", 20)) ELSE 0 END`.)
 
 **Weighting** (`--hist-weight`, `--overlay histogram` only):
 - `count` (default) — each contributing pixel counts as 1.
@@ -367,10 +377,25 @@ With no `--hist-bins`/`--hist-width`, behaviour is unchanged (exact-value counts
 
 **Normalization** (`--hist-normalize`, either mode):
 - `none` (default) — raw counts (or area weights).
-- `cell-area` — divide by the DGGS cell's own area in m², giving a density-like value per bin.
+- `cell-area` — divide by the DGGS cell's own area in m², giving a density-like value per bin. Only valid with `--hist-weight area` (an area divided by area is a meaningful fraction; a pixel *count* divided by area is a density in a different, less useful unit, so this combination is rejected).
 - `valid-overlap` — divide by the total weight of all valid contributing pixels, so a cell's bins sum to ≤ 1 (< 1 if some values were dropped as out-of-range by `--hist-bins`).
 
-`counts` becomes `float64` (rather than `int64`) whenever weighting or normalization is active, since the result is no longer a plain pixel count. `-d`/`--decimals` rounds `counts` in that case but never rounds bin edges (`values`) themselves.
+Both the bins field(s) and the weight field are named for what they actually contain, rather than using fixed terms.
+
+| `--hist-bins`/`--hist-width` | bins field(s) | `--hist-weight` | `--hist-normalize` | weight field | weight type |
+|---|---|---|---|---|---|
+| not set | `values: list<T>` | `count` | `none` | `counts` | `int64` |
+| not set | `values: list<T>` | `count` | `valid-overlap` | `count_frac` | `float64` |
+| not set | `values: list<T>` | `area` | `none` | `area` | `float64` |
+| not set | `values: list<T>` | `area` | `cell-area` | `area_frac` | `float64` |
+| not set | `values: list<T>` | `area` | `valid-overlap` | `area_share` | `float64` |
+| set | `left: list<float64>`, `right: list<float64>` | `count` | `none` | `counts` | `int64` |
+| set | `left: list<float64>`, `right: list<float64>` | `count` | `valid-overlap` | `count_frac` | `float64` |
+| set | `left: list<float64>`, `right: list<float64>` | `area` | `none` | `area` | `float64` |
+| set | `left: list<float64>`, `right: list<float64>` | `area` | `cell-area` | `area_frac` | `float64` |
+| set | `left: list<float64>`, `right: list<float64>` | `area` | `valid-overlap` | `area_share` | `float64` |
+
+`-d`/`--decimals` rounds the weight field when it's `float64`, but never rounds `values`/`left`/`right` themselves.
 
 ```bash
 # Explicit bins, elevation histogram per cell
@@ -380,7 +405,7 @@ raster2dggs h3 dem.tif output/ -r 8 --point histogram --hist-bins 0,500,1000,150
 raster2dggs h3 dem.tif output/ -r 8 --overlay histogram --hist-width 100 --hist-weight area --hist-normalize valid-overlap -d none
 ```
 
-The bin configuration (mode, edges/width/origin, weight, normalize) is recorded once as Parquet schema metadata under the `raster2dggs:histogram` key, so output files remain self-describing.
+The bin configuration (mode, edges/width/origin, weight, normalize) is also recorded once as Parquet schema metadata under the `raster2dggs:histogram` key.
 
 This option has no effect for `--overlay mass-preserve`. Partial sums produced by `mass-preserve` are correct values representing the fraction of mass within the cell–raster intersection; filtering them out would break the mass-conservation guarantee. `--overlay density-preserve` respects the threshold normally — a cell with insufficient valid coverage will be nulled.
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,20 @@ GDAL_CACHEMAX=512 raster2dggs h3 input.tif output/ -r 8 --overlay weighted
 
 The value is in megabytes. The default is 64 MB. For large rasters or high DGGS resolutions where each window covers many cells, a larger cache can significantly reduce processing time.
 
+**Check your input's internal tiling.** raster2dggs processes one GDAL block at a time (`src.block_windows()`), for every mode — `--point`, `--sample`, and `--overlay` alike. Some GeoTIFFs (particularly ones exported without explicit tiling options) are stored as *strips* — one block per row — rather than square tiles. A strip-encoded raster can produce thousands of tiny windows instead of a few hundred properly-sized ones, and since each window carries its own per-window overhead (more so for `--overlay`, which re-derives the set of overlapping DGGS cells per window), this can turn an otherwise-quick job into one that appears to hang. Check with:
+
+```bash
+gdalinfo input.tif | grep Block=
+```
+
+`Block=<width>x1` (block height of 1) means it's strip-encoded. If so, re-tile it first:
+
+```bash
+gdal_translate -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 input.tif input_tiled.tif
+```
+
+(If `gdal_translate` warns about the CRS definition not matching the EPSG registry, prefer re-tiling via `rasterio` directly instead, copying `src.profile`/`src.crs` as-is, to avoid GDAL rewriting the projection metadata.)
+
 #### Valid-data coverage threshold (`-vct` / `--valid-coverage-threshold`)
 
 By default (`-vct 0.0`) any cell with at least one valid pixel in its overlap area receives a value. Use `--valid-coverage-threshold` to require a minimum fraction of the cell's raster-overlapping area to have valid (non-nodata) data:
@@ -709,6 +723,16 @@ raster2dggs h3 --resolution 7 --point list -d 2 input.tif ./output
 Histogram of contributing pixel values per cell:
 ```bash
 raster2dggs h3 --resolution 7 --point histogram -d 0 input.tif ./output
+```
+
+Numeric histogram of a continuous field (e.g. DEM), binned into 100 m intervals:
+```bash
+raster2dggs h3 --resolution 8 --point histogram --hist-width 100 input.tif ./output
+```
+
+Area-weighted histogram per cell, explicit bins, normalised so each cell's bins sum to ~1:
+```bash
+raster2dggs h3 --resolution 8 --overlay histogram --hist-bins 0,500,1000,1500,2000,inf --hist-weight area --hist-normalize valid-overlap -d none input.tif ./output
 ```
 
 Nearest-neighbour sampling for a continuous field (e.g. DEM, temperature grid):

--- a/README.md
+++ b/README.md
@@ -361,7 +361,9 @@ The threshold is applied **per band**: a cell may receive a valid value for one 
 
 With binning active, each populated bin's own bounds are reported directly (as two parallel arrays, `left`/`right`) alongside its weight, rather than requiring you to already know the bin configuration to interpret a row. Every bin, in every band and every row of a given output, is half-open `[left, right)`, except the very last bin overall, which is also closed on the right — a fixed rule of the tool (matching `numpy.histogram`'s convention), not something that can vary bin-to-bin, so it isn't stored per bin.
 
-Only non-empty bins are reported, and a bin's position in the arrays isn't fixed — cell A might have `[20,50)` at index 0, cell B at index 3, cell C not at all. To pull out a specific bin's value (e.g. in a QGIS expression or a SQL query), search by value rather than by position, e.g. in QGIS:
+Only non-empty bins are reported, and a bin's position in the arrays isn't fixed — cell A might have `[20,50)` at index 0, cell B at index 3, cell C not at all. So pull out a specific bin's value by searching for it, not by a fixed array index.
+
+For example, to style a layer in QGIS by the `[20,50)` bin's `area_share` — open the file as a vector layer (QGIS's native GeoParquet/Parquet support needs QGIS ≥ 3.32 with a recent enough GDAL), then use this as the expression in the Field Calculator (to materialise a new field) or as a data-defined override on a symbol/label property:
 
 ```
 with_variable('idx', array_find("band_1.left", 20),
@@ -369,7 +371,15 @@ with_variable('idx', array_find("band_1.left", 20),
 )
 ```
 
-(the `ELSE 0` handles a cell that had nothing in that bin at all, since it's sparse, not an error — and note the `@idx` references to the variable, not `'idx'`/`"idx"`: single quotes are a QGIS string literal, double quotes are a field reference, and neither is the same as `@idx`, the actual variable reference. If `with_variable` still doesn't resolve inside the `CASE` in your QGIS version/context, repeat the `array_find` call instead of relying on the variable: `CASE WHEN array_find("band_1.left", 20) >= 0 THEN array_get("band_1.area_share", array_find("band_1.left", 20)) ELSE 0 END`.)
+`"band_1.left"`/`"band_1.area_share"` are the dotted names GDAL's Parquet driver gives to struct sub-fields — check the actual field names for your file in QGIS's Fields panel/Browser, since the band column name (`band_1` here) depends on your raster's band labels. `with_variable`'s first argument, `'idx'` (the name being *defined*), stays a single-quoted string; every later *use* of it must be `@idx` — QGIS variables always take the `@` prefix, and `'idx'`/`"idx"` (string literal / field reference) are different things that will fail. The `ELSE 0` handles a cell with nothing in that bin at all — sparse, not an error.
+
+If `with_variable` doesn't resolve inside the `CASE` for you (a known QGIS scoping quirk in some versions/contexts), skip it and just repeat the search:
+
+```
+CASE WHEN array_find("band_1.left", 20) >= 0
+     THEN array_get("band_1.area_share", array_find("band_1.left", 20))
+     ELSE 0 END
+```
 
 **Weighting** (`--hist-weight`, `--overlay histogram` only):
 - `count` (default) — each contributing pixel counts as 1.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Contributions (particularly for additional DGGSs), suggestions, bug reports and 
 - [Sampling strategies](#sampling-strategies)
   - [Point sampling (default)](#point-sampling-default---point)
   - [Overlay (area-based)](#overlay-area-based---overlay)
+  - [Numeric (binned) histograms](#numeric-binned-histograms---hist-bins---hist-width)
   - [Windowed resampling](#windowed-resampling---sample)
 - [Visualising output](#visualising-output)
   - [DuckDB](#duckdb)
@@ -192,6 +193,35 @@ Options:
                                   are correct values — filtering them would
                                   break mass conservation).  [default: 0.0;
                                   0.0<=x<=1.0]
+  --hist-bins EDGE,EDGE[,...]     Explicit ascending histogram bin edges for
+                                  --point/--overlay histogram. Bins are half-
+                                  open [a, b); the last bin is closed. Values
+                                  outside the range are dropped. Use -inf/inf
+                                  for open-ended end bins. Mutually exclusive
+                                  with --hist-width. Only meaningful with
+                                  --point histogram or --overlay histogram.
+  --hist-width FLOAT              Uniform histogram bin width for
+                                  --point/--overlay histogram. Bins are
+                                  [origin + k*width, origin + (k+1)*width);
+                                  every finite value falls in a bin (nothing
+                                  is dropped). Mutually exclusive with
+                                  --hist-bins.
+  --hist-origin FLOAT             Anchor for --hist-width bins (a bin edge is
+                                  placed at this value).  [default: 0.0]
+  --hist-weight [count|area]      Histogram weighting: 'count' (number of
+                                  contributing pixels), 'area' (each pixel
+                                  weighted by its overlap area with the cell,
+                                  in m², geodesic for geographic CRS). 'area'
+                                  requires --overlay histogram.  [default:
+                                  count]
+  --hist-normalize [none|cell-area|valid-overlap]
+                                  Histogram normalization: 'none' (raw
+                                  counts/weights), 'cell-area' (divide by the
+                                  DGGS cell's area in m²), 'valid-overlap'
+                                  (divide by the total weight of all valid
+                                  contributing pixels, so bins sum to ≤ 1).
+                                  Non-integer results make counts float64.
+                                  [default: none]
   -d, --decimals INTEGER|none     Decimal places to round output values. 0 =
                                   integer; negative values round to tens (-1),
                                   hundreds (-2), etc. Use 'none' to disable
@@ -227,7 +257,7 @@ Each raster pixel centre is indexed to its containing DGGS cell. When multiple p
 **Output modes** (pass as `--point OUTPUT`):
 - *(no arg / `--point value`)* — scalar per cell per band; use `--agg min,max` etc. for multi-agg struct output
 - `--point list` — sorted list of all contributing pixel values: `list<T>` per band. `--agg` is ignored.
-- `--point histogram` — value-count histogram: `struct<values: list<T>, counts: list<int64>>` per band. `--agg` is ignored.
+- `--point histogram` — value-count histogram: `struct<values: list<T>, counts: list<int64>>` per band. `--agg` is ignored. Pass `--hist-bins`/`--hist-width` to bin continuous data instead of counting exact values — see [Numeric (binned) histograms](#numeric-binned-histograms---hist-bins---hist-width).
 
 ```bash
 # Default: mean of all contributing pixels
@@ -239,8 +269,11 @@ raster2dggs h3 input.tif output/ -r 9 --agg min,max
 # Sorted list of all pixel values per cell
 raster2dggs h3 input.tif output/ -r 7 --point list -d 2
 
-# Histogram of pixel values per cell
+# Histogram of pixel values per cell (categorical: exact value counts)
 raster2dggs h3 input.tif output/ -r 7 --point histogram -d 0
+
+# Histogram of continuous data, binned into 10-unit-wide bins
+raster2dggs h3 input.tif output/ -r 7 --point histogram --hist-width 10
 ```
 
 ### Overlay (area-based) — `--overlay METHOD`
@@ -255,7 +288,7 @@ Uses [exactextract](https://github.com/isciences/exactextract) to compute exact 
 | `density-preserve` | Scalar `T` per band | Density rasters (W/m², kg/km²) — integrates density × pixel area to give the cell total; geographic CRS uses geodesic pixel areas |
 | `fractions` | `struct<classes: list<int64>, fractions: list<float64>>` per band | Class area fractions within each DGGS cell |
 | `list` | `list<T>` per band | All overlapping pixel values as a sorted list (collect mode) |
-| `histogram` | `struct<values: list<T>, counts: list<int64>>` per band | Histogram of overlapping pixel values |
+| `histogram` | `struct<values: list<T>, counts: list<int64>>` per band | Histogram of overlapping pixel values. Add `--hist-bins`/`--hist-width` for continuous data, `--hist-weight area` to weight by overlap area instead of pixel count — see [Numeric (binned) histograms](#numeric-binned-histograms---hist-bins---hist-width) |
 
 ```bash
 # Area-weighted mean (intensive quantities)
@@ -276,8 +309,11 @@ raster2dggs h3 landcover.tif output/ -r 8 --overlay fractions
 # Collect all overlapping pixel values as a list
 raster2dggs h3 input.tif output/ -r 8 --overlay list
 
-# Histogram of all overlapping pixel values
+# Histogram of all overlapping pixel values (categorical: exact value counts)
 raster2dggs h3 input.tif output/ -r 8 --overlay histogram
+
+# Area-weighted histogram, binned into 10-unit-wide bins
+raster2dggs h3 input.tif output/ -r 8 --overlay histogram --hist-width 10 --hist-weight area
 ```
 
 #### Performance note
@@ -300,6 +336,37 @@ raster2dggs h3 input.tif output/ -r 8 --overlay mode -vct 0.5
 ```
 
 The threshold is applied **per band**: a cell may receive a valid value for one band and be nulled for another if that band has sparser nodata. Nulled values are then handled by `--nodata` — the default `omit` drops rows where any band is null; `emit` keeps them as NaN (or `--nodata-fill` if set).
+
+### Numeric (binned) histograms — `--hist-bins`/`--hist-width`
+
+`--point histogram` and `--overlay histogram` count *exact* pixel values by default — useful for categorical rasters (land cover classes, masks), but not meaningful for continuous data (elevation, temperature), where every pixel is likely to have a distinct value. Pass `--hist-bins` or `--hist-width` to bin continuous values into a proper numeric histogram instead:
+
+- `--hist-bins EDGE,EDGE[,...]` — explicit ascending bin edges, e.g. `--hist-bins 0,10,20,50`. Bins are half-open `[a, b)`; the last bin is closed (a value exactly equal to the final edge is included, not dropped). Values outside `[first_edge, last_edge]` are dropped — use `-inf`/`inf` as the first/last edge to catch everything. Output `values` are the *lower* edge of each populated bin (only non-empty bins are reported).
+- `--hist-width FLOAT` (with optional `--hist-origin FLOAT`, default `0.0`) — uniform-width bins `[origin + k·width, origin + (k+1)·width)`. Unlike explicit edges, this is unbounded — every finite value falls into some bin, so nothing is dropped.
+- `--hist-bins` and `--hist-width` are mutually exclusive.
+
+With no `--hist-bins`/`--hist-width`, behaviour is unchanged (exact-value counts).
+
+**Weighting** (`--hist-weight`, `--overlay histogram` only):
+- `count` (default) — each contributing pixel counts as 1.
+- `area` — each pixel is weighted by its overlap area with the cell, in m² (geodesic for geographic CRS rasters, matching `--overlay density-preserve`). Requires `--overlay histogram`; undefined for `--point histogram` since pixel-cell overlap area isn't computed on that path.
+
+**Normalization** (`--hist-normalize`, either mode):
+- `none` (default) — raw counts (or area weights).
+- `cell-area` — divide by the DGGS cell's own area in m², giving a density-like value per bin.
+- `valid-overlap` — divide by the total weight of all valid contributing pixels, so a cell's bins sum to ≤ 1 (< 1 if some values were dropped as out-of-range by `--hist-bins`).
+
+`counts` becomes `float64` (rather than `int64`) whenever weighting or normalization is active, since the result is no longer a plain pixel count. `-d`/`--decimals` rounds `counts` in that case but never rounds bin edges (`values`) themselves.
+
+```bash
+# Explicit bins, elevation histogram per cell
+raster2dggs h3 dem.tif output/ -r 8 --point histogram --hist-bins 0,500,1000,1500,2000,inf
+
+# Uniform 100 m bins, area-weighted, normalized so each cell's bins sum to ~1
+raster2dggs h3 dem.tif output/ -r 8 --overlay histogram --hist-width 100 --hist-weight area --hist-normalize valid-overlap -d none
+```
+
+The bin configuration (mode, edges/width/origin, weight, normalize) is recorded once as Parquet schema metadata under the `raster2dggs:histogram` key, so output files remain self-describing.
 
 This option has no effect for `--overlay mass-preserve`. Partial sums produced by `mass-preserve` are correct values representing the fraction of mass within the cell–raster intersection; filtering them out would break the mass-conservation guarantee. `--overlay density-preserve` respects the threshold normally — a cell with insufficient valid coverage will be nulled.
 

--- a/raster2dggs/cli_factory.py
+++ b/raster2dggs/cli_factory.py
@@ -57,6 +57,29 @@ class DecimalsParamType(click.ParamType):
         return "INTEGER|none"
 
 
+class BinEdgesParamType(click.ParamType):
+    """Accepts 2+ strictly ascending, comma-separated bin edges (-inf/inf allowed)."""
+
+    name = "EDGES"
+
+    def convert(self, value, param, ctx):
+        if isinstance(value, tuple):
+            return value
+        parts = [p.strip() for p in str(value).split(",")]
+        try:
+            edges = tuple(float(p) for p in parts)
+        except ValueError:
+            self.fail(f"'{value}': expected comma-separated numbers", param, ctx)
+        if len(edges) < 2:
+            self.fail("--hist-bins requires at least 2 edges", param, ctx)
+        if any(b <= a for a, b in zip(edges, edges[1:])):
+            self.fail(f"'{value}': edges must be strictly ascending", param, ctx)
+        return edges
+
+    def get_metavar(self, param, ctx=None):
+        return "EDGE,EDGE[,...]"
+
+
 class ResolutionParamType(click.ParamType):
     """Accepts an integer resolution in [min_res, max_res] or a named auto-detection mode."""
 
@@ -166,6 +189,11 @@ def run_index(
     overlay: Optional[str],
     sample: Optional[str],
     valid_coverage_threshold: float = 0.0,
+    hist_bins: Optional[tuple] = None,
+    hist_width: Optional[float] = None,
+    hist_origin: float = 0.0,
+    hist_weight: str = "count",
+    hist_normalize: str = "none",
 ):
     tempfile.tempdir = tempdir if tempdir is not None else tempfile.tempdir
 
@@ -185,6 +213,11 @@ def run_index(
         overlay,
         sample,
         valid_coverage_threshold,
+        hist_bins,
+        hist_width,
+        hist_origin,
+        hist_weight,
+        hist_normalize,
     )
 
     common.initial_index(
@@ -361,6 +394,66 @@ def make_command(spec: DGGS_Spec):
         ),
     )
     @click.option(
+        "--hist-bins",
+        "hist_bins",
+        default=None,
+        type=BinEdgesParamType(),
+        metavar="EDGE,EDGE[,...]",
+        help=(
+            "Explicit ascending histogram bin edges for --point/--overlay histogram. "
+            "Bins are half-open [a, b); the last bin is closed. Values outside the "
+            "range are dropped. Use -inf/inf for open-ended end bins. "
+            "Mutually exclusive with --hist-width. Only meaningful with "
+            "--point histogram or --overlay histogram."
+        ),
+    )
+    @click.option(
+        "--hist-width",
+        "hist_width",
+        default=None,
+        type=float,
+        metavar="FLOAT",
+        help=(
+            "Uniform histogram bin width for --point/--overlay histogram. Bins are "
+            "[origin + k*width, origin + (k+1)*width); every finite value falls in a "
+            "bin (nothing is dropped). Mutually exclusive with --hist-bins."
+        ),
+    )
+    @click.option(
+        "--hist-origin",
+        "hist_origin",
+        default=0.0,
+        type=float,
+        show_default=True,
+        metavar="FLOAT",
+        help="Anchor for --hist-width bins (a bin edge is placed at this value).",
+    )
+    @click.option(
+        "--hist-weight",
+        "hist_weight",
+        default="count",
+        type=click.Choice([w.value for w in const.HistWeight]),
+        show_default=True,
+        help=(
+            "Histogram weighting: 'count' (number of contributing pixels), 'area' "
+            "(each pixel weighted by its overlap area with the cell, in m^2; "
+            "geodesic for geographic CRS). 'area' requires --overlay histogram."
+        ),
+    )
+    @click.option(
+        "--hist-normalize",
+        "hist_normalize",
+        default="none",
+        type=click.Choice([n.value for n in const.HistNormalize]),
+        show_default=True,
+        help=(
+            "Histogram normalization: 'none' (raw counts/weights), 'cell-area' "
+            "(divide by the DGGS cell's area in m^2), 'valid-overlap' (divide by "
+            "the total weight of all valid contributing pixels, so bins sum to <= 1). "
+            "Non-integer results make counts float64."
+        ),
+    )
+    @click.option(
         "-d",
         "--decimals",
         default=const.DEFAULTS["decimals"],
@@ -408,6 +501,11 @@ def make_command(spec: DGGS_Spec):
         overlay,
         sample,
         valid_coverage_threshold,
+        hist_bins,
+        hist_width,
+        hist_origin,
+        hist_weight,
+        hist_normalize,
     ):
         if isinstance(resolution, str):
             raster_path = common.resolve_input_path(raster_input)
@@ -443,6 +541,26 @@ def make_command(spec: DGGS_Spec):
                 "--nodata-fill has no effect when --nodata=omit (the default). "
                 "Add --nodata emit to write the specified value for nodata cells."
             )
+        hist_flag_names = {
+            "hist_bins": "--hist-bins",
+            "hist_width": "--hist-width",
+            "hist_origin": "--hist-origin",
+            "hist_weight": "--hist-weight",
+            "hist_normalize": "--hist-normalize",
+        }
+        hist_from_cli = {
+            p: ctx.get_parameter_source(p) == click.core.ParameterSource.COMMANDLINE
+            for p in hist_flag_names
+        }
+        is_histogram_out = point == "histogram" or overlay == "histogram"
+        if not is_histogram_out:
+            for pname, flag in hist_flag_names.items():
+                if hist_from_cli[pname]:
+                    common.LOGGER.warning(
+                        f"{flag}: no effect (output is not histogram)"
+                    )
+        elif hist_width is None and hist_from_cli["hist_origin"]:
+            common.LOGGER.warning("--hist-origin has no effect without --hist-width")
         return run_index(
             spec.name,
             raster_input,
@@ -464,6 +582,11 @@ def make_command(spec: DGGS_Spec):
             overlay,
             sample,
             valid_coverage_threshold,
+            hist_bins,
+            hist_width,
+            hist_origin,
+            hist_weight,
+            hist_normalize,
         )
 
     return cmd

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -269,6 +269,7 @@ def validate_config(
     hist_bins: Optional[Sequence[float]] = None,
     hist_width: Optional[float] = None,
     hist_weight: Optional[str] = None,
+    hist_normalize: Optional[str] = None,
 ) -> None:
     if overlay is not None and sample is not None:
         raise click.UsageError("--overlay and --sample are mutually exclusive")
@@ -282,6 +283,15 @@ def validate_config(
         raise click.UsageError(
             "--hist-weight area requires --overlay histogram "
             "(area weighting is undefined for --point/--sample)"
+        )
+    if (
+        hist_weight == const.HistWeight.COUNT
+        and hist_normalize == const.HistNormalize.CELL_AREA
+    ):
+        raise click.UsageError(
+            "--hist-weight count with --hist-normalize cell-area is not supported "
+            "(a pixel count divided by area is a density, not a count or a fraction -- "
+            "use --hist-weight area instead)"
         )
 
 
@@ -498,22 +508,13 @@ def _build_write_schema(
             ]
         )
     if out == const.OutputSchema.HISTOGRAM:
-        fields = []
-        for c in band_cols:
-            values_type, counts_type = histogram.hist_arrow_types(
-                hist_spec, decimals, source_dtypes[c]
+        fields = [
+            pa.field(
+                c,
+                histogram.histogram_struct_type(hist_spec, decimals, source_dtypes[c]),
             )
-            fields.append(
-                pa.field(
-                    c,
-                    pa.struct(
-                        [
-                            pa.field("values", pa.list_(values_type)),
-                            pa.field("counts", pa.list_(counts_type)),
-                        ]
-                    ),
-                )
-            )
+            for c in band_cols
+        ]
         return pa.schema(common_fields + fields)
     if len(aggfuncs) > 1:
         return pa.schema(
@@ -736,6 +737,7 @@ def initial_index(
         kwargs.get("hist_bins"),
         kwargs.get("hist_width"),
         kwargs.get("hist_weight"),
+        kwargs.get("hist_normalize"),
     )
     internal = resolve_to_internal(
         kwargs.get("point"),

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -33,6 +33,7 @@ from rasterio.warp import transform_bounds
 from rasterio.transform import rowcol
 
 import raster2dggs.constants as const
+import raster2dggs.histogram as histogram
 import raster2dggs.indexerfactory as idxfactory
 
 from raster2dggs.interfaces import IRasterIndexer
@@ -246,10 +247,28 @@ def resolve_to_internal(
     return {"transfer": const.Transfer.ASSIGN_CENTERS, "op": None, "out": out}
 
 
+def _build_histogram_spec(kwargs: dict) -> Optional[histogram.HistogramSpec]:
+    """Build a HistogramSpec from raw --hist-* CLI values, or None when the
+    resolved output isn't histogram (the --hist-* flags then have no effect)."""
+    if kwargs.get("out") != const.OutputSchema.HISTOGRAM:
+        return None
+    hist_bins = kwargs.get("hist_bins")
+    return histogram.HistogramSpec(
+        edges=tuple(hist_bins) if hist_bins else None,
+        width=kwargs.get("hist_width"),
+        origin=kwargs.get("hist_origin") or 0.0,
+        weight=kwargs.get("hist_weight") or const.HistWeight.COUNT,
+        normalize=kwargs.get("hist_normalize") or const.HistNormalize.NONE,
+    )
+
+
 def validate_config(
     point: Optional[str],
     overlay: Optional[str],
     sample: Optional[str],
+    hist_bins: Optional[Sequence[float]] = None,
+    hist_width: Optional[float] = None,
+    hist_weight: Optional[str] = None,
 ) -> None:
     if overlay is not None and sample is not None:
         raise click.UsageError("--overlay and --sample are mutually exclusive")
@@ -257,6 +276,13 @@ def validate_config(
         raise click.UsageError("--point and --overlay are mutually exclusive")
     if point is not None and sample is not None:
         raise click.UsageError("--point and --sample are mutually exclusive")
+    if hist_bins is not None and hist_width is not None:
+        raise click.UsageError("--hist-bins and --hist-width are mutually exclusive")
+    if hist_weight == const.HistWeight.AREA and overlay != const.OverlayMode.HISTOGRAM:
+        raise click.UsageError(
+            "--hist-weight area requires --overlay histogram "
+            "(area weighting is undefined for --point/--sample)"
+        )
 
 
 def assemble_kwargs(
@@ -271,6 +297,11 @@ def assemble_kwargs(
     overlay: Optional[str] = None,
     sample: Optional[str] = None,
     valid_coverage_threshold: float = 0.0,
+    hist_bins: Optional[Tuple[float, ...]] = None,
+    hist_width: Optional[float] = None,
+    hist_origin: float = 0.0,
+    hist_weight: str = "count",
+    hist_normalize: str = "none",
 ) -> dict:
     return {
         "compression": compression,
@@ -284,6 +315,11 @@ def assemble_kwargs(
         "overlay": overlay,
         "sample": sample,
         "valid_coverage_threshold": valid_coverage_threshold,
+        "hist_bins": hist_bins,
+        "hist_width": hist_width,
+        "hist_origin": hist_origin,
+        "hist_weight": hist_weight,
+        "hist_normalize": hist_normalize,
     }
 
 
@@ -439,6 +475,7 @@ def _build_write_schema(
     index_col: str,
     partition_col: str,
     out_meta: pd.DataFrame,
+    hist_spec: Optional[histogram.HistogramSpec] = None,
 ) -> pa.Schema:
     common_fields = [
         pa.field(index_col, pa.string()),
@@ -461,24 +498,23 @@ def _build_write_schema(
             ]
         )
     if out == const.OutputSchema.HISTOGRAM:
-        return pa.schema(
-            common_fields
-            + [
+        fields = []
+        for c in band_cols:
+            values_type, counts_type = histogram.hist_arrow_types(
+                hist_spec, decimals, source_dtypes[c]
+            )
+            fields.append(
                 pa.field(
                     c,
                     pa.struct(
                         [
-                            pa.field(
-                                "values",
-                                pa.list_(_element_type(source_dtypes[c], decimals)),
-                            ),
-                            pa.field("counts", pa.list_(pa.int64())),
+                            pa.field("values", pa.list_(values_type)),
+                            pa.field("counts", pa.list_(counts_type)),
                         ]
                     ),
                 )
-                for c in band_cols
-            ]
-        )
+            )
+        return pa.schema(common_fields + fields)
     if len(aggfuncs) > 1:
         return pa.schema(
             common_fields
@@ -580,7 +616,14 @@ def address_boundary_issues(
     )
     band_cols = [c for c in ddf.columns if not c.startswith(f"{indexer.dggs}_")]
     # Capture source dtypes before map_partitions changes them.
-    source_dtypes = {c: ddf[c].dtype for c in band_cols}
+    # Stage 1 output for --overlay list/histogram already holds aggregated
+    # python list/dict objects, so re-reading it here gives dtype "object" --
+    # not the original raster pixel dtype. Prefer the dtypes captured directly
+    # from the source raster (kwargs["source_pixel_dtypes"], set in
+    # initial_index) when available; they agree with ddf[c].dtype for every
+    # other output mode, where Stage 1 still holds unaggregated scalar values.
+    source_pixel_dtypes = kwargs.get("source_pixel_dtypes") or {}
+    source_dtypes = {c: source_pixel_dtypes.get(c, ddf[c].dtype) for c in band_cols}
 
     out = kwargs.get("out", const.OutputSchema.VALUE)
     transfer = kwargs.get("transfer", const.Transfer.ASSIGN_CENTERS)
@@ -609,7 +652,7 @@ def address_boundary_issues(
             mp_args = (resolution, parent_res, decimals)
         elif out == const.OutputSchema.HISTOGRAM:
             mp_func = indexer.parent_groupby_histogram
-            mp_args = (resolution, parent_res, decimals)
+            mp_args = (resolution, parent_res, decimals, kwargs.get("hist_spec"))
         else:
             mp_func = indexer.parent_groupby
             mp_args = (resolution, parent_res, aggfuncs, decimals)
@@ -621,6 +664,7 @@ def address_boundary_issues(
                 indexer.compaction, resolution, parent_res, meta=out_meta
             )
 
+        hist_spec = kwargs.get("hist_spec")
         write_schema = _build_write_schema(
             out=out,
             aggfuncs=aggfuncs,
@@ -630,7 +674,24 @@ def address_boundary_issues(
             index_col=index_col,
             partition_col=partition_col,
             out_meta=out_meta,
+            hist_spec=hist_spec,
         )
+        if out == const.OutputSchema.HISTOGRAM and hist_spec is not None:
+            hist_meta = {
+                "mode": "binned" if hist_spec.binned else "categorical",
+                "edges": list(hist_spec.edges) if hist_spec.edges else None,
+                "width": hist_spec.width,
+                "origin": hist_spec.origin,
+                "weight": str(hist_spec.weight),
+                "normalize": str(hist_spec.normalize),
+            }
+            existing_meta = write_schema.metadata or {}
+            write_schema = write_schema.with_metadata(
+                {
+                    **existing_meta,
+                    b"raster2dggs:histogram": json.dumps(hist_meta).encode("utf-8"),
+                }
+            )
 
         _write_output(
             ddf,
@@ -672,6 +733,9 @@ def initial_index(
         kwargs.get("point"),
         kwargs.get("overlay"),
         kwargs.get("sample"),
+        kwargs.get("hist_bins"),
+        kwargs.get("hist_width"),
+        kwargs.get("hist_weight"),
     )
     internal = resolve_to_internal(
         kwargs.get("point"),
@@ -679,6 +743,7 @@ def initial_index(
         kwargs.get("sample"),
     )
     kwargs = {**kwargs, **internal}
+    kwargs["hist_spec"] = _build_histogram_spec(kwargs)
 
     indexer = idxfactory.indexer_instance(dggs)
 
@@ -775,6 +840,10 @@ def initial_index(
                 )
 
                 selected_labels = tuple([labels_by_index[i] for i in selected_indices])
+                kwargs["source_pixel_dtypes"] = {
+                    label: np.dtype(src.dtypes[idx - 1])
+                    for idx, label in zip(selected_indices, selected_labels)
+                }
                 compression = kwargs["compression"]
                 nodata = src.nodata
 
@@ -835,6 +904,7 @@ def initial_index(
                         out=kwargs["out"],
                         min_valid_coverage=kwargs.get("valid_coverage_threshold", 0.0),
                         decimals=kwargs.get("decimals"),
+                        hist_spec=kwargs.get("hist_spec"),
                     )
                     stage1_func = ctx.process_window
                 else:

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -174,6 +174,17 @@ class OutputSchema(StrEnum):
     LIST = "list"
 
 
+class HistWeight(StrEnum):
+    COUNT = "count"
+    AREA = "area"
+
+
+class HistNormalize(StrEnum):
+    NONE = "none"
+    CELL_AREA = "cell-area"
+    VALID_OVERLAP = "valid-overlap"
+
+
 # The four distinct internal transfer implementations for overlay.
 # Multiple OverlayMode values can map to the same Transfer (e.g. 'weighted',
 # 'density-preserve', and 'fractions' all use OVERLAY_WEIGHTED; 'list' and

--- a/raster2dggs/histogram.py
+++ b/raster2dggs/histogram.py
@@ -5,6 +5,23 @@ Both code paths collect per-cell contributing pixel values (optionally with
 per-pixel weights, e.g. overlap area) and need identical binning/weighting/
 normalization semantics; this module is the single implementation both call
 into, so a change here (or a bug fix) applies uniformly to both.
+
+Output shape:
+  - Categorical (no binning): {"values": [...], <weight_field>: [...]} --
+    exact pixel values paired with a summed weight per value.
+  - Binned: {"left": [...], "right": [...], <weight_field>: [...]} -- three
+    parallel lists, all indexed the same way, so bin i spans [left[i],
+    right[i]) and has weight <weight_field>[i]. Every bin is half-open
+    [left, right), except the final bin of an explicit --hist-bins run,
+    which is also right-closed (matching numpy.histogram's convention).
+    This closedness rule is fixed for every bin, so it isn't stored
+    per-bin -- see the --hist-bins/--hist-width CLI help for the
+    definitive statement of it.
+
+<weight_field> (see weight_field_name) is named for what the numbers
+represent: a plain pixel count is "counts", but an area sum or a normalized
+fraction is named accordingly (e.g. "area", "area_frac") since those numbers
+aren't counts.
 """
 
 from __future__ import annotations
@@ -33,6 +50,29 @@ class HistogramSpec:
         return self.edges is not None or self.width is not None
 
 
+_WEIGHT_FIELD_NAMES = {
+    (const.HistWeight.COUNT, const.HistNormalize.NONE): "counts",
+    (const.HistWeight.COUNT, const.HistNormalize.VALID_OVERLAP): "count_frac",
+    (const.HistWeight.AREA, const.HistNormalize.NONE): "area",
+    (const.HistWeight.AREA, const.HistNormalize.CELL_AREA): "area_frac",
+    (const.HistWeight.AREA, const.HistNormalize.VALID_OVERLAP): "area_share",
+}
+
+
+def weight_field_name(spec: Optional[HistogramSpec]) -> str:
+    """Name of the per-bin weight field for this spec's (weight, normalize)
+    combination -- chosen so the field describes what the numbers are (a
+    plain pixel count, an area in m^2, or a fraction of some denominator)."""
+    spec = spec or HistogramSpec()
+    key = (spec.weight, spec.normalize)
+    if key not in _WEIGHT_FIELD_NAMES:
+        raise ValueError(
+            f"--hist-weight {spec.weight} with --hist-normalize {spec.normalize} "
+            "is not a supported combination"
+        )
+    return _WEIGHT_FIELD_NAMES[key]
+
+
 def build_histogram(
     values: Sequence[float],
     weights: Optional[Sequence[float]] = None,
@@ -41,17 +81,16 @@ def build_histogram(
     cell_area: Optional[float] = None,
 ) -> Optional[dict]:
     """
-    Build a {"values": [...], "counts": [...]} histogram from contributing
-    pixel values (and optional per-pixel weights).
+    Build a histogram from contributing pixel values (and optional per-pixel
+    weights). See module docstring for the returned shape.
 
     - spec is None or categorical (`not spec.binned`): an exact-value
       histogram -- unique (optionally decimals-rounded) values, each paired
       with its summed weight (1 per pixel when weights is None).
-    - spec.binned: bins values into `spec.edges` (explicit, numpy
-      half-open-except-last-bin-closed convention, out-of-range values
-      dropped) or uniform `spec.width`/`spec.origin` bins (unbounded --
-      every finite value falls in some bin). Result "values" are bin lower
-      edges, float64, sparse (only non-empty bins are reported).
+    - spec.binned: bins values into `spec.edges` (explicit, out-of-range
+      values dropped) or uniform `spec.width`/`spec.origin` bins (unbounded
+      -- every finite value falls in some bin). Only non-empty bins are
+      reported (sparse).
 
     Normalization (spec.normalize):
       - NONE: raw summed weight per bin/value.
@@ -77,60 +116,71 @@ def build_histogram(
     total_valid_weight = float(w.sum())
 
     spec = spec or HistogramSpec()
+    field = weight_field_name(spec)
 
     if not spec.binned:
-        out_values, out_counts = _categorical(arr, w, decimals)
-    elif spec.edges is not None:
-        out_values, out_counts = _binned_explicit(arr, w, spec.edges)
+        keys, out_weight = _categorical(arr, w, decimals)
+        if len(keys) == 0:
+            return None
+        bins_payload = {"values": keys}
     else:
-        out_values, out_counts = _binned_uniform(arr, w, spec.width, spec.origin)
-
-    if len(out_values) == 0:
-        return None
+        if spec.edges is not None:
+            lefts, rights, out_weight = _binned_explicit(arr, w, spec.edges)
+        else:
+            lefts, rights, out_weight = _binned_uniform(arr, w, spec.width, spec.origin)
+        if len(lefts) == 0:
+            return None
+        bins_payload = {"left": lefts, "right": rights}
 
     if spec.normalize == const.HistNormalize.VALID_OVERLAP:
         if total_valid_weight <= 0:
             return None
-        out_counts = out_counts / total_valid_weight
+        out_weight = out_weight / total_valid_weight
     elif spec.normalize == const.HistNormalize.CELL_AREA:
         if not cell_area or cell_area <= 0:
             return None
-        out_counts = out_counts / cell_area
+        out_weight = out_weight / cell_area
 
-    is_plain_count = (
-        spec.weight == const.HistWeight.COUNT
-        and spec.normalize == const.HistNormalize.NONE
-    )
-    if is_plain_count:
-        out_counts_list: list = out_counts.astype(np.int64).tolist()
+    if field == "counts":
+        weight_list: list = out_weight.astype(np.int64).tolist()
     else:
         if decimals is not None:
-            out_counts = np.round(out_counts, decimals)
-        out_counts_list = out_counts.tolist()
+            out_weight = np.round(out_weight, decimals)
+        weight_list = out_weight.tolist()
 
-    return {"values": out_values, "counts": out_counts_list}
+    return {**bins_payload, field: weight_list}
 
 
-def hist_arrow_types(
+def histogram_struct_type(
     spec: Optional[HistogramSpec], decimals: Optional[int], source_dtype
-) -> tuple[pa.DataType, pa.DataType]:
-    """Arrow (values_type, counts_type) for a histogram struct column, matching
-    build_histogram's output shape for the given spec/decimals/source dtype."""
+) -> pa.StructType:
+    """Arrow struct type for a histogram column, matching build_histogram's
+    output shape for the given spec/decimals/source dtype."""
     spec = spec or HistogramSpec()
+    field = weight_field_name(spec)
+    weight_type = pa.int64() if field == "counts" else pa.float64()
+
     if spec.binned:
-        values_type = pa.float64()
-    elif decimals is not None and decimals <= 0:
+        return pa.struct(
+            [
+                pa.field("left", pa.list_(pa.float64())),
+                pa.field("right", pa.list_(pa.float64())),
+                pa.field(field, pa.list_(weight_type)),
+            ]
+        )
+
+    if decimals is not None and decimals <= 0:
         values_type = pa.int64()
     elif decimals is not None:
         values_type = pa.float64()
     else:
         values_type = pa.from_numpy_dtype(source_dtype)
-    is_plain_count = (
-        spec.weight == const.HistWeight.COUNT
-        and spec.normalize == const.HistNormalize.NONE
+    return pa.struct(
+        [
+            pa.field("values", pa.list_(values_type)),
+            pa.field(field, pa.list_(weight_type)),
+        ]
     )
-    counts_type = pa.int64() if is_plain_count else pa.float64()
-    return values_type, counts_type
 
 
 def _weighted_groupby(keys: np.ndarray, w: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -156,20 +206,22 @@ def _categorical(
 
 def _binned_explicit(
     arr: np.ndarray, w: np.ndarray, edges: Union[tuple, Sequence[float]]
-) -> tuple[list, np.ndarray]:
+) -> tuple[list, list, np.ndarray]:
     edges_arr = np.asarray(edges, dtype=np.float64)
     # numpy's own bin convention: half-open [a, b) except the last bin,
     # which is closed -- exactly the semantics --hist-bins documents.
     dense_counts, _ = np.histogram(arr, bins=edges_arr, weights=w)
     nonzero = dense_counts != 0
-    lower_edges = edges_arr[:-1][nonzero]
-    return lower_edges.tolist(), dense_counts[nonzero]
+    lefts = edges_arr[:-1][nonzero]
+    rights = edges_arr[1:][nonzero]
+    return lefts.tolist(), rights.tolist(), dense_counts[nonzero]
 
 
 def _binned_uniform(
     arr: np.ndarray, w: np.ndarray, width: float, origin: float
-) -> tuple[list, np.ndarray]:
+) -> tuple[list, list, np.ndarray]:
     bin_idx = np.floor((arr - origin) / width).astype(np.int64)
     unique_bins, summed = _weighted_groupby(bin_idx, w)
-    lower_edges = origin + unique_bins.astype(np.float64) * width
-    return lower_edges.tolist(), summed
+    lefts = origin + unique_bins.astype(np.float64) * width
+    rights = lefts + width
+    return lefts.tolist(), rights.tolist(), summed

--- a/raster2dggs/histogram.py
+++ b/raster2dggs/histogram.py
@@ -1,0 +1,175 @@
+"""
+Shared histogram building for --point histogram and --overlay histogram.
+
+Both code paths collect per-cell contributing pixel values (optionally with
+per-pixel weights, e.g. overlap area) and need identical binning/weighting/
+normalization semantics; this module is the single implementation both call
+into, so a change here (or a bug fix) applies uniformly to both.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pyarrow as pa
+
+import raster2dggs.constants as const
+
+
+@dataclasses.dataclass(frozen=True)
+class HistogramSpec:
+    """Primitives-only so it tokenizes cleanly across a dask task graph."""
+
+    edges: Optional[tuple] = None  # explicit ascending bin edges
+    width: Optional[float] = None  # uniform bin width
+    origin: float = 0.0  # anchor for width-mode bins
+    weight: str = const.HistWeight.COUNT
+    normalize: str = const.HistNormalize.NONE
+
+    @property
+    def binned(self) -> bool:
+        return self.edges is not None or self.width is not None
+
+
+def build_histogram(
+    values: Sequence[float],
+    weights: Optional[Sequence[float]] = None,
+    spec: Optional[HistogramSpec] = None,
+    decimals: Optional[int] = None,
+    cell_area: Optional[float] = None,
+) -> Optional[dict]:
+    """
+    Build a {"values": [...], "counts": [...]} histogram from contributing
+    pixel values (and optional per-pixel weights).
+
+    - spec is None or categorical (`not spec.binned`): an exact-value
+      histogram -- unique (optionally decimals-rounded) values, each paired
+      with its summed weight (1 per pixel when weights is None).
+    - spec.binned: bins values into `spec.edges` (explicit, numpy
+      half-open-except-last-bin-closed convention, out-of-range values
+      dropped) or uniform `spec.width`/`spec.origin` bins (unbounded --
+      every finite value falls in some bin). Result "values" are bin lower
+      edges, float64, sparse (only non-empty bins are reported).
+
+    Normalization (spec.normalize):
+      - NONE: raw summed weight per bin/value.
+      - VALID_OVERLAP: divide by the total weight of all valid (non-NaN)
+        input values, computed *before* any out-of-range dropping -- so a
+        set of bins can sum to < 1 if values were dropped as out-of-range.
+      - CELL_AREA: divide by `cell_area` (caller-supplied; required if used).
+
+    Returns None if there is nothing to report.
+    """
+    if values is None or len(values) == 0:
+        return None
+    arr = np.asarray(values, dtype=np.float64)
+    valid = ~np.isnan(arr)
+    if not valid.any():
+        return None
+    arr = arr[valid]
+    w = (
+        np.ones_like(arr)
+        if weights is None
+        else np.asarray(weights, dtype=np.float64)[valid]
+    )
+    total_valid_weight = float(w.sum())
+
+    spec = spec or HistogramSpec()
+
+    if not spec.binned:
+        out_values, out_counts = _categorical(arr, w, decimals)
+    elif spec.edges is not None:
+        out_values, out_counts = _binned_explicit(arr, w, spec.edges)
+    else:
+        out_values, out_counts = _binned_uniform(arr, w, spec.width, spec.origin)
+
+    if len(out_values) == 0:
+        return None
+
+    if spec.normalize == const.HistNormalize.VALID_OVERLAP:
+        if total_valid_weight <= 0:
+            return None
+        out_counts = out_counts / total_valid_weight
+    elif spec.normalize == const.HistNormalize.CELL_AREA:
+        if not cell_area or cell_area <= 0:
+            return None
+        out_counts = out_counts / cell_area
+
+    is_plain_count = (
+        spec.weight == const.HistWeight.COUNT
+        and spec.normalize == const.HistNormalize.NONE
+    )
+    if is_plain_count:
+        out_counts_list: list = out_counts.astype(np.int64).tolist()
+    else:
+        if decimals is not None:
+            out_counts = np.round(out_counts, decimals)
+        out_counts_list = out_counts.tolist()
+
+    return {"values": out_values, "counts": out_counts_list}
+
+
+def hist_arrow_types(
+    spec: Optional[HistogramSpec], decimals: Optional[int], source_dtype
+) -> tuple[pa.DataType, pa.DataType]:
+    """Arrow (values_type, counts_type) for a histogram struct column, matching
+    build_histogram's output shape for the given spec/decimals/source dtype."""
+    spec = spec or HistogramSpec()
+    if spec.binned:
+        values_type = pa.float64()
+    elif decimals is not None and decimals <= 0:
+        values_type = pa.int64()
+    elif decimals is not None:
+        values_type = pa.float64()
+    else:
+        values_type = pa.from_numpy_dtype(source_dtype)
+    is_plain_count = (
+        spec.weight == const.HistWeight.COUNT
+        and spec.normalize == const.HistNormalize.NONE
+    )
+    counts_type = pa.int64() if is_plain_count else pa.float64()
+    return values_type, counts_type
+
+
+def _weighted_groupby(keys: np.ndarray, w: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Group `w` by `keys`, returning (sorted unique keys, summed weight per key)."""
+    unique_keys, inverse = np.unique(keys, return_inverse=True)
+    summed = np.zeros(len(unique_keys), dtype=np.float64)
+    np.add.at(summed, inverse, w)
+    return unique_keys, summed
+
+
+def _categorical(
+    arr: np.ndarray, w: np.ndarray, decimals: Optional[int]
+) -> tuple[list, np.ndarray]:
+    if decimals is not None and decimals <= 0:
+        keys = np.round(arr, decimals).astype(np.int64)
+    elif decimals is not None:
+        keys = np.round(arr, decimals)
+    else:
+        keys = arr
+    unique_keys, summed = _weighted_groupby(keys, w)
+    return unique_keys.tolist(), summed
+
+
+def _binned_explicit(
+    arr: np.ndarray, w: np.ndarray, edges: Union[tuple, Sequence[float]]
+) -> tuple[list, np.ndarray]:
+    edges_arr = np.asarray(edges, dtype=np.float64)
+    # numpy's own bin convention: half-open [a, b) except the last bin,
+    # which is closed -- exactly the semantics --hist-bins documents.
+    dense_counts, _ = np.histogram(arr, bins=edges_arr, weights=w)
+    nonzero = dense_counts != 0
+    lower_edges = edges_arr[:-1][nonzero]
+    return lower_edges.tolist(), dense_counts[nonzero]
+
+
+def _binned_uniform(
+    arr: np.ndarray, w: np.ndarray, width: float, origin: float
+) -> tuple[list, np.ndarray]:
+    bin_idx = np.floor((arr - origin) / width).astype(np.int64)
+    unique_bins, summed = _weighted_groupby(bin_idx, w)
+    lower_edges = origin + unique_bins.astype(np.float64) * width
+    return lower_edges.tolist(), summed

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -352,11 +352,10 @@ class RasterIndexer(IRasterIndexer):
     ) -> pd.DataFrame:
         """
         Collect contributing pixel values per DGGS cell into a histogram.
-        Used with --out histogram. Each band column becomes a dict
-        {"values": [...], "counts": [...]} -- see
-        raster2dggs.histogram.build_histogram for the binning/weighting/
-        normalization semantics controlled by hist_spec (None gives an
-        exact-value, unweighted histogram).
+        Used with --out histogram. Each band column becomes the dict built by
+        raster2dggs.histogram.build_histogram, which also documents the
+        binning/weighting/normalization semantics controlled by hist_spec
+        (None gives an exact-value, unweighted histogram).
         """
         gb = self._collect_lists(df, resolution, parent_res)
         cell_areas = None

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -7,6 +7,7 @@ import xarray as xr
 import numpy as np
 
 from .. import constants as const
+from ..histogram import HistogramSpec, build_histogram
 from ..interfaces import IRasterIndexer
 
 
@@ -267,7 +268,15 @@ class RasterIndexer(IRasterIndexer):
                 gb = gb.astype({c: "float64" for c in to_promote})
             gb = gb.round(decimals)
         else:
-            gb = gb.round(decimals).astype("Int64")
+            # Only cast numeric columns to Int64 -- object columns (e.g. list/dict
+            # values from --overlay list/histogram routed through this dedup path)
+            # must be left untouched; .astype("Int64") on the whole frame raises.
+            gb = gb.round(decimals)
+            to_cast = gb.select_dtypes(
+                include=["float32", "float64", "integer"]
+            ).columns
+            if len(to_cast):
+                gb = gb.astype({c: "Int64" for c in to_cast})
         gb = gb.reset_index(level=0)
         gb.index.name = index_col
         return gb
@@ -339,32 +348,40 @@ class RasterIndexer(IRasterIndexer):
         resolution: int,
         parent_res: int,
         decimals: Optional[int] = None,
+        hist_spec: Optional[HistogramSpec] = None,
     ) -> pd.DataFrame:
         """
-        Collect contributing pixel values per DGGS cell as a value-count histogram.
+        Collect contributing pixel values per DGGS cell into a histogram.
         Used with --out histogram. Each band column becomes a dict
-        {"values": [sorted unique values], "counts": [corresponding counts]}.
+        {"values": [...], "counts": [...]} -- see
+        raster2dggs.histogram.build_histogram for the binning/weighting/
+        normalization semantics controlled by hist_spec (None gives an
+        exact-value, unweighted histogram).
         """
         gb = self._collect_lists(df, resolution, parent_res)
+        cell_areas = None
+        if (
+            hist_spec is not None
+            and hist_spec.normalize == const.HistNormalize.CELL_AREA
+        ):
+            lons, lats = self.cells_to_lonlat_arrays(pd.Series(gb.index))
+            cell_areas = [
+                self.cell_area_m2(resolution, lat, lon) for lat, lon in zip(lats, lons)
+            ]
         for col in self.band_cols(gb):
-
-            def _to_hist(lst, _decimals=decimals):
-                if _decimals is not None and _decimals <= 0:
-                    vals = [int(round(float(v), _decimals)) for v in lst]
-                elif _decimals is not None:
-                    vals = [round(float(v), _decimals) for v in lst]
-                else:
-                    vals = list(lst)
-                counts: dict = {}
-                for v in vals:
-                    counts[v] = counts.get(v, 0) + 1
-                sorted_keys = sorted(counts.keys())
-                return {
-                    "values": sorted_keys,
-                    "counts": [counts[k] for k in sorted_keys],
-                }
-
-            gb[col] = gb[col].map(_to_hist)
+            if cell_areas is not None:
+                gb[col] = [
+                    build_histogram(
+                        vals, spec=hist_spec, decimals=decimals, cell_area=area
+                    )
+                    for vals, area in zip(gb[col], cell_areas)
+                ]
+            else:
+                gb[col] = gb[col].map(
+                    lambda vals: build_histogram(
+                        vals, spec=hist_spec, decimals=decimals
+                    )
+                )
         return gb
 
     @staticmethod

--- a/raster2dggs/transfers/overlay.py
+++ b/raster2dggs/transfers/overlay.py
@@ -32,7 +32,7 @@ from rasterio.warp import transform_bounds, transform as warp_transform
 from shapely.geometry import Polygon, shape
 
 import raster2dggs.constants as const
-from raster2dggs.histogram import HistogramSpec, build_histogram, hist_arrow_types
+from raster2dggs.histogram import HistogramSpec, build_histogram, histogram_struct_type
 from raster2dggs.interfaces import IRasterIndexer
 
 LOGGER = logging.getLogger(__name__)
@@ -89,15 +89,7 @@ def _build_collect_table(
             elem_type = _pa_elem_type(src_dtypes[idx - 1], decimals)
             arrays[col] = pa.array(result_df[col].tolist(), type=pa.list_(elem_type))
         else:
-            values_type, counts_type = hist_arrow_types(
-                hist_spec, decimals, src_dtypes[idx - 1]
-            )
-            hist_type = pa.struct(
-                [
-                    pa.field("values", pa.list_(values_type)),
-                    pa.field("counts", pa.list_(counts_type)),
-                ]
-            )
+            hist_type = histogram_struct_type(hist_spec, decimals, src_dtypes[idx - 1])
             arrays[col] = pa.array(result_df[col].tolist(), type=hist_type)
     return pa.table(arrays)
 

--- a/raster2dggs/transfers/overlay.py
+++ b/raster2dggs/transfers/overlay.py
@@ -32,6 +32,7 @@ from rasterio.warp import transform_bounds, transform as warp_transform
 from shapely.geometry import Polygon, shape
 
 import raster2dggs.constants as const
+from raster2dggs.histogram import HistogramSpec, build_histogram, hist_arrow_types
 from raster2dggs.interfaces import IRasterIndexer
 
 LOGGER = logging.getLogger(__name__)
@@ -61,16 +62,6 @@ def _frac_pairs(frac_arr, unique_arr, scale=1.0, decimals=None):
     return {"classes": [k for k, _ in pairs], "fractions": fracs}
 
 
-def _build_histogram(arr, decimals=None) -> Optional[dict]:
-    """Return {"values": [...], "counts": [...]} from a pixel-value array, or None if empty."""
-    if arr is None or len(arr) == 0:
-        return None
-    if decimals is not None:
-        arr = np.round(arr, decimals)
-    unique, counts = np.unique(arr, return_counts=True)
-    return {"values": unique.tolist(), "counts": counts.astype(np.int64).tolist()}
-
-
 def _pa_elem_type(numpy_dtype_str: str, decimals) -> pa.DataType:
     if decimals is not None and decimals <= 0:
         return pa.int64()
@@ -86,6 +77,7 @@ def _build_collect_table(
     selected_indices: tuple,
     out: str,
     decimals,
+    hist_spec: Optional[HistogramSpec] = None,
 ) -> pa.Table:
     """Build a PyArrow Table for --overlay --list or --overlay --histogram output."""
     arrays = {}
@@ -93,14 +85,17 @@ def _build_collect_table(
         if col not in band_cols:
             arrays[col] = pa.array(result_df[col].tolist())
     for idx, col in zip(selected_indices, band_cols):
-        elem_type = _pa_elem_type(src_dtypes[idx - 1], decimals)
         if out == const.OutputSchema.LIST:
+            elem_type = _pa_elem_type(src_dtypes[idx - 1], decimals)
             arrays[col] = pa.array(result_df[col].tolist(), type=pa.list_(elem_type))
         else:
+            values_type, counts_type = hist_arrow_types(
+                hist_spec, decimals, src_dtypes[idx - 1]
+            )
             hist_type = pa.struct(
                 [
-                    pa.field("values", pa.list_(elem_type)),
-                    pa.field("counts", pa.list_(pa.int64())),
+                    pa.field("values", pa.list_(values_type)),
+                    pa.field("counts", pa.list_(counts_type)),
                 ]
             )
             arrays[col] = pa.array(result_df[col].tolist(), type=hist_type)
@@ -153,6 +148,7 @@ class _OverlayIndexer:
     out: const.OutputSchema = const.OutputSchema.VALUE
     min_valid_coverage: float = 0.0
     decimals: Optional[int] = None
+    hist_spec: Optional[HistogramSpec] = None
 
     def __post_init__(self):
         # mass_preserve (sum) must not filter by coverage — partial sums are correct
@@ -174,10 +170,18 @@ class _OverlayIndexer:
             self._src_band_count = src.count
             self._src_dtypes = src.dtypes
 
+            wants_area_weighted_hist = (
+                self.op == const.Op.VALUES
+                and self.hist_spec is not None
+                and self.hist_spec.weight == const.HistWeight.AREA
+            )
             if (
-                self.op == const.Op.MEAN and src.crs.is_geographic
-            ) or self.op == const.Op.WSUM:
-                # Pixel-area weights raster for exactextract weighted_mean / weighted_sum.
+                (self.op == const.Op.MEAN and src.crs.is_geographic)
+                or self.op == const.Op.WSUM
+                or wants_area_weighted_hist
+            ):
+                # Pixel-area weights raster for exactextract weighted_mean / weighted_sum,
+                # or as the per-pixel area weight for --hist-weight area.
                 # For geographic CRS: geodesic area varies by row (latitude); use pyproj.
                 # For projected CRS (wsum only): pixel area is constant from the transform.
                 T = src.transform
@@ -279,7 +283,13 @@ class _OverlayIndexer:
         # exactextract column naming:
         #   unweighted: "{op}" (single-band) or "band_{i}_{op}" (multi-band)
         #   weighted:   "weighted_{op}" (single-band) or "band_{i}_weight_weighted_{op}" (multi-band)
-        if self._geodesic_weights_path is not None:
+        # Only MEAN/WSUM use the weighted-aggregate op names above -- a weights
+        # raster built for --hist-weight area (op VALUES) uses plain "values"/
+        # "coverage"/"weights" column names instead, handled separately below.
+        if self._geodesic_weights_path is not None and self.op in (
+            const.Op.MEAN,
+            const.Op.WSUM,
+        ):
             weighted_agg = (
                 "weighted_sum" if self.op == const.Op.WSUM else "weighted_mean"
             )
@@ -318,7 +328,9 @@ class _OverlayIndexer:
         except Exception:
             # Suppress destructor-time errors (e.g., interpreter shutdown), but keep
             # a debug trace for troubleshooting.
-            LOGGER.debug("Ignoring exception during _OverlayIndexer.__del__", exc_info=True)
+            LOGGER.debug(
+                "Ignoring exception during _OverlayIndexer.__del__", exc_info=True
+            )
 
     def process_window(self, window):
         """Compute overlay stats for all DGGS cells overlapping this raster window."""
@@ -368,9 +380,23 @@ class _OverlayIndexer:
         is_frac = self.op == const.Op.FRAC
         is_collect = self.op == const.Op.VALUES
         is_geodesic = self._geodesic_weights_path is not None
+        is_area_weighted_hist = (
+            is_collect
+            and self.hist_spec is not None
+            and self.hist_spec.weight == const.HistWeight.AREA
+        )
         weighted_agg = "weighted_sum" if self.op == const.Op.WSUM else "weighted_mean"
         if is_frac:
             main_ops = ["frac", "unique"]
+        elif is_collect:
+            # Collect ops (--overlay list/histogram) always use exactextract's plain
+            # "values"/"coverage"/"weights" array ops -- never the weighted-aggregate
+            # op names below, even when a weights raster exists for area weighting.
+            main_ops = (
+                ["values", "coverage", "weights"]
+                if is_area_weighted_hist
+                else ["values"]
+            )
         elif is_geodesic:
             main_ops = [weighted_agg]
         else:
@@ -429,15 +455,21 @@ class _OverlayIndexer:
             for idx in self.selected_indices:
                 if self._src_band_count == 1:
                     vf = cov_df["mean"] * raster_fracs
-                    main_col = weighted_agg if is_geodesic else self.op
+                    if is_collect:
+                        main_col = "values"
+                    else:
+                        main_col = weighted_agg if is_geodesic else self.op
                     unique_col = "unique"
                 else:
                     vf = cov_df[f"band_{idx}_mean"] * raster_fracs
-                    main_col = (
-                        f"band_{idx}_weight_{weighted_agg}"
-                        if is_geodesic
-                        else f"band_{idx}_{self.op}"
-                    )
+                    if is_collect:
+                        main_col = f"band_{idx}_values"
+                    else:
+                        main_col = (
+                            f"band_{idx}_weight_{weighted_agg}"
+                            if is_geodesic
+                            else f"band_{idx}_{self.op}"
+                        )
                     unique_col = f"band_{idx}_unique"
                 valid_frac_by_band[idx] = vf
                 if self._apply_coverage_threshold:
@@ -476,6 +508,16 @@ class _OverlayIndexer:
                 .any(axis=1)
             )
         elif is_collect:
+            cell_areas_by_id = None
+            if (
+                self.hist_spec is not None
+                and self.hist_spec.normalize == const.HistNormalize.CELL_AREA
+            ):
+                lons, lats = self.indexer.cells_to_lonlat_arrays(result_df["_cell_id"])
+                cell_areas_by_id = {
+                    cid: self.indexer.cell_area_m2(self.resolution, lat, lon)
+                    for cid, lat, lon in zip(result_df["_cell_id"], lats, lons)
+                }
             for idx, label in zip(self.selected_indices, self.selected_labels):
                 vc = "values" if self._src_band_count == 1 else f"band_{idx}_values"
                 raw = result_df[vc]
@@ -493,8 +535,42 @@ class _OverlayIndexer:
                         for arr in raw
                     ]
                 else:
+                    if is_area_weighted_hist:
+                        cc = (
+                            "coverage"
+                            if self._src_band_count == 1
+                            else f"band_{idx}_coverage"
+                        )
+                        wc = (
+                            "weights"
+                            if self._src_band_count == 1
+                            else f"band_{idx}_weights"
+                        )
+                        weight_arrs = [
+                            (
+                                (c * w)
+                                if (arr is not None and c is not None and w is not None)
+                                else None
+                            )
+                            for arr, c, w in zip(raw, result_df[cc], result_df[wc])
+                        ]
+                    else:
+                        weight_arrs = [None] * len(raw)
                     result_df[label] = [
-                        _build_histogram(arr, self.decimals) for arr in raw
+                        build_histogram(
+                            arr,
+                            weights=wgt,
+                            spec=self.hist_spec,
+                            decimals=self.decimals,
+                            cell_area=(
+                                cell_areas_by_id.get(cid)
+                                if cell_areas_by_id is not None
+                                else None
+                            ),
+                        )
+                        for arr, wgt, cid in zip(
+                            raw, weight_arrs, result_df["_cell_id"]
+                        )
                     ]
             result_df = result_df[["_cell_id"] + band_cols]
 
@@ -549,6 +625,7 @@ class _OverlayIndexer:
                 self.selected_indices,
                 self.out,
                 self.decimals,
+                hist_spec=self.hist_spec,
             )
         else:
             table = pa.Table.from_pandas(result_df, preserve_index=False)

--- a/tests/classes/helpers.py
+++ b/tests/classes/helpers.py
@@ -32,3 +32,25 @@ def make_raster(
         nodata=nodata,
     ) as dst:
         dst.write(data)
+
+
+def make_gradient_raster(
+    path: str,
+    bounds: tuple,
+    size: int,
+) -> None:
+    """Write a single-band float32 WGS84 GeoTIFF with continuous, non-uniform
+    values (0..size*size-1) for use in numeric histogram binning tests."""
+    data = np.arange(size * size, dtype=np.float32).reshape(1, size, size)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype="float32",
+        crs=CRS.from_epsg(4326),
+        transform=from_bounds(*bounds, size, size),
+    ) as dst:
+        dst.write(data)

--- a/tests/classes/test_histogram_binning.py
+++ b/tests/classes/test_histogram_binning.py
@@ -1,0 +1,286 @@
+"""
+Tests for numeric (binned) histograms: https://github.com/manaakiwhenua/raster2dggs/issues/68.
+
+Categorical (unbinned) histogram behaviour is covered by test_output_schema.py;
+these tests focus on --hist-bins/--hist-width/--hist-weight/--hist-normalize.
+"""
+
+import pyarrow as pa
+from click.testing import CliRunner
+
+from classes.base import TestRunthrough, read_output
+from classes.helpers import make_gradient_raster, make_raster
+from data.datapaths import TEST_OUTPUT_PATH
+from raster2dggs.cli import cli
+
+# 10x10 pixel raster, values 0..99 (gradient) or a fixed value (uniform).
+# H3 res 5 cells are ~252 km^2, well over the ~93 km^2 raster extent, so the
+# whole raster is covered by a small number of cells -- large enough lists to
+# exercise binning meaningfully.
+_BOUNDS = (174.0, -41.1, 174.1, -41.0)
+_SIZE = 10
+_RES = 5
+
+
+def _make_gradient(path: str) -> None:
+    make_gradient_raster(path, _BOUNDS, _SIZE)
+
+
+def _make_uniform(path: str, value: float = 7.0) -> None:
+    make_raster(path, _BOUNDS, _SIZE, pixel_value=value)
+
+
+class _HistTestBase(TestRunthrough):
+    def setUp(self):
+        super().setUp()
+        self._gradient = self.make_temp_raster(_make_gradient)
+        self._uniform = self.make_temp_raster(_make_uniform)
+
+    def _run(self, raster, *extra_args):
+        self.invoke_cli("h3", raster, TEST_OUTPUT_PATH, _RES, *extra_args)
+        return read_output(TEST_OUTPUT_PATH)
+
+    def _non_null_histograms(self, table, col="band_1"):
+        return [v for v in table.to_pandas()[col] if v is not None]
+
+
+class TestPointHistBinsExplicit(_HistTestBase):
+    def test_schema_types(self):
+        table = self._run(
+            self._gradient, "--point", "histogram", "--hist-bins", "0,25,50,75,100"
+        )
+        struct_type = table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("values").type, pa.list_(pa.float64()))
+        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.int64()))
+
+    def test_bin_edges_are_lower_edges_of_populated_bins(self):
+        table = self._run(
+            self._gradient, "--point", "histogram", "--hist-bins", "0,25,50,75,100"
+        )
+        for hist in self._non_null_histograms(table):
+            for v in hist["values"]:
+                self.assertIn(v, (0.0, 25.0, 50.0, 75.0))
+
+    def test_nothing_dropped_when_bins_cover_full_range(self):
+        table = self._run(
+            self._gradient, "--point", "histogram", "--hist-bins", "0,25,50,75,100"
+        )
+        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        self.assertEqual(total, _SIZE * _SIZE)
+
+    def test_out_of_range_values_dropped(self):
+        table = self._run(
+            self._gradient, "--point", "histogram", "--hist-bins", "10,90"
+        )
+        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        self.assertLess(total, _SIZE * _SIZE)
+
+    def test_open_ended_edges_drop_nothing(self):
+        table = self._run(
+            self._gradient, "--point", "histogram", "--hist-bins", "-inf,50,inf"
+        )
+        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        self.assertEqual(total, _SIZE * _SIZE)
+
+    def test_last_bin_is_closed(self):
+        # A value exactly at the final edge (99 is the max value; use an edge
+        # that lands exactly on a present value) must be included, not dropped.
+        table = self._run(self._gradient, "--point", "histogram", "--hist-bins", "0,99")
+        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        # Values 0..98 fall in [0, 99); value 99 must also be counted (closed
+        # last bin), so nothing in range [0, 99] is dropped.
+        self.assertEqual(total, _SIZE * _SIZE)
+
+
+class TestPointHistWidth(_HistTestBase):
+    def test_edges_match_origin_plus_k_width(self):
+        table = self._run(self._gradient, "--point", "histogram", "--hist-width", "25")
+        for hist in self._non_null_histograms(table):
+            for v in hist["values"]:
+                self.assertEqual(v % 25, 0.0)
+
+    def test_width_mode_drops_nothing(self):
+        table = self._run(self._gradient, "--point", "histogram", "--hist-width", "25")
+        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        self.assertEqual(total, _SIZE * _SIZE)
+
+    def test_origin_shifts_bin_edges(self):
+        default_table = self._run(
+            self._gradient, "--point", "histogram", "--hist-width", "25"
+        )
+        shifted_table = self._run(
+            self._gradient,
+            "--point",
+            "histogram",
+            "--hist-width",
+            "25",
+            "--hist-origin",
+            "10",
+        )
+        default_edges = {
+            v for h in self._non_null_histograms(default_table) for v in h["values"]
+        }
+        shifted_edges = {
+            v for h in self._non_null_histograms(shifted_table) for v in h["values"]
+        }
+        self.assertNotEqual(default_edges, shifted_edges)
+        for edge in shifted_edges:
+            self.assertEqual((edge - 10) % 25, 0.0)
+
+    def test_bins_and_width_mutually_exclusive(self):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "h3",
+                str(self._gradient),
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_RES),
+                "--point",
+                "histogram",
+                "--hist-bins",
+                "0,50,100",
+                "--hist-width",
+                "25",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestPointHistNormalize(_HistTestBase):
+    def test_valid_overlap_sums_to_one_per_cell(self):
+        table = self._run(
+            self._gradient,
+            "--point",
+            "histogram",
+            "--hist-normalize",
+            "valid-overlap",
+            "-d",
+            "none",
+        )
+        struct_type = table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.float64()))
+        for hist in self._non_null_histograms(table):
+            self.assertAlmostEqual(sum(hist["counts"]), 1.0, places=6)
+
+    def test_cell_area_normalize_gives_positive_floats(self):
+        table = self._run(
+            self._gradient,
+            "--point",
+            "histogram",
+            "--hist-normalize",
+            "cell-area",
+            "-d",
+            "none",
+        )
+        for hist in self._non_null_histograms(table):
+            for c in hist["counts"]:
+                self.assertGreater(c, 0.0)
+
+
+class TestOverlayHistBinned(_HistTestBase):
+    def test_negative_decimals_does_not_crash(self):
+        # Regression test: parent_groupby_nn's Int64 cast used to run on the
+        # whole (object-dtype) frame for decimals <= 0, raising for the
+        # dict-valued histogram column produced by --overlay histogram.
+        table = self._run(
+            self._gradient,
+            "--overlay",
+            "histogram",
+            "--hist-bins",
+            "0,25,50,75,100",
+            "-d",
+            "0",
+        )
+        struct_type = table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.int64()))
+        self.assertGreater(len(self._non_null_histograms(table)), 0)
+
+    def test_categorical_mode_unaffected_by_new_flags(self):
+        # No --hist-* flags: schema and values must match plain --overlay histogram.
+        with_flags = self._run(self._uniform, "--overlay", "histogram")
+        without_flags_schema = with_flags.schema.field("band_1").type
+        self.assertEqual(
+            without_flags_schema.field("values").type, pa.list_(pa.float64())
+        )
+        self.assertEqual(
+            without_flags_schema.field("counts").type, pa.list_(pa.int64())
+        )
+        for hist in self._non_null_histograms(with_flags):
+            self.assertEqual(hist["values"], [7.0])
+
+
+class TestOverlayHistAreaWeight(_HistTestBase):
+    def test_area_weight_requires_overlay_histogram(self):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "h3",
+                str(self._uniform),
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_RES),
+                "--point",
+                "histogram",
+                "--hist-weight",
+                "area",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_area_weighted_totals_conserve_raster_area(self):
+        # Summed across every cell the raster overlaps, area-weighted counts
+        # (coverage x geodesic pixel area) must reconstruct the raster's own
+        # total geodesic area -- nothing gained or lost by partitioning across
+        # H3 cells.
+        table = self._run(
+            self._uniform,
+            "--overlay",
+            "histogram",
+            "--hist-weight",
+            "area",
+            "-d",
+            "none",
+        )
+        struct_type = table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.float64()))
+        total_area = sum(
+            sum(hist["counts"]) for hist in self._non_null_histograms(table)
+        )
+        # Independently computed geodesic area of the (uniform, single-valued)
+        # raster: bounds (174.0,-41.1)-(174.1,-41.0) is about 93.4 km^2.
+        self.assertAlmostEqual(total_area, 93_365_567.0, delta=50_000.0)
+
+    def test_area_weight_and_cell_area_normalize_matches_fractions(self):
+        # struct<values,counts> from an area-weighted, cell-area-normalized
+        # histogram on a single-valued raster should give ~ the same
+        # class-fraction as --overlay fractions for that (only) class.
+        hist_table = self._run(
+            self._uniform,
+            "--overlay",
+            "histogram",
+            "--hist-weight",
+            "area",
+            "--hist-normalize",
+            "cell-area",
+            "-d",
+            "none",
+        )
+        frac_table = self._run(self._uniform, "--overlay", "fractions", "-d", "none")
+
+        hist_by_cell = dict(
+            zip(hist_table.to_pandas().index, hist_table.to_pandas()["band_1"])
+        )
+        frac_by_cell = dict(
+            zip(frac_table.to_pandas().index, frac_table.to_pandas()["band_1"])
+        )
+        compared = 0
+        for cell_id, hist in hist_by_cell.items():
+            if hist is None:
+                continue
+            frac = frac_by_cell.get(cell_id)
+            if frac is None:
+                continue
+            self.assertAlmostEqual(hist["counts"][0], frac["fractions"][0], delta=0.02)
+            compared += 1
+        self.assertGreater(compared, 0)

--- a/tests/classes/test_histogram_binning.py
+++ b/tests/classes/test_histogram_binning.py
@@ -5,13 +5,17 @@ Categorical (unbinned) histogram behaviour is covered by test_output_schema.py;
 these tests focus on --hist-bins/--hist-width/--hist-weight/--hist-normalize.
 """
 
+from unittest import TestCase
+
 import pyarrow as pa
 from click.testing import CliRunner
 
+import raster2dggs.constants as const
 from classes.base import TestRunthrough, read_output
 from classes.helpers import make_gradient_raster, make_raster
 from data.datapaths import TEST_OUTPUT_PATH
 from raster2dggs.cli import cli
+from raster2dggs.histogram import HistogramSpec, build_histogram, weight_field_name
 
 # 10x10 pixel raster, values 0..99 (gradient) or a fixed value (uniform).
 # H3 res 5 cells are ~252 km^2, well over the ~93 km^2 raster extent, so the
@@ -28,6 +32,55 @@ def _make_gradient(path: str) -> None:
 
 def _make_uniform(path: str, value: float = 7.0) -> None:
     make_raster(path, _BOUNDS, _SIZE, pixel_value=value)
+
+
+class TestWeightFieldNaming(TestCase):
+    """Pure unit tests for the (weight, normalize) -> field-name mapping and
+    the interval shape of binned histograms -- no raster I/O needed."""
+
+    def test_count_none_is_counts(self):
+        self.assertEqual(weight_field_name(HistogramSpec()), "counts")
+
+    def test_count_valid_overlap_is_count_frac(self):
+        spec = HistogramSpec(normalize=const.HistNormalize.VALID_OVERLAP)
+        self.assertEqual(weight_field_name(spec), "count_frac")
+
+    def test_area_none_is_area(self):
+        spec = HistogramSpec(weight=const.HistWeight.AREA)
+        self.assertEqual(weight_field_name(spec), "area")
+
+    def test_area_cell_area_is_area_frac(self):
+        spec = HistogramSpec(
+            weight=const.HistWeight.AREA, normalize=const.HistNormalize.CELL_AREA
+        )
+        self.assertEqual(weight_field_name(spec), "area_frac")
+
+    def test_area_valid_overlap_is_area_share(self):
+        spec = HistogramSpec(
+            weight=const.HistWeight.AREA, normalize=const.HistNormalize.VALID_OVERLAP
+        )
+        self.assertEqual(weight_field_name(spec), "area_share")
+
+    def test_count_cell_area_is_rejected(self):
+        spec = HistogramSpec(
+            weight=const.HistWeight.COUNT, normalize=const.HistNormalize.CELL_AREA
+        )
+        with self.assertRaises(ValueError):
+            weight_field_name(spec)
+
+    def test_binned_result_has_left_right_not_values(self):
+        hist = build_histogram([1, 6, 11], spec=HistogramSpec(width=5, origin=0))
+        self.assertIn("left", hist)
+        self.assertIn("right", hist)
+        self.assertNotIn("values", hist)
+        self.assertEqual(hist["left"], [0.0, 5.0, 10.0])
+        self.assertEqual(hist["right"], [5.0, 10.0, 15.0])
+
+    def test_categorical_result_has_values_not_left_right(self):
+        hist = build_histogram([1, 1, 2])
+        self.assertIn("values", hist)
+        self.assertNotIn("left", hist)
+        self.assertNotIn("right", hist)
 
 
 class _HistTestBase(TestRunthrough):
@@ -50,16 +103,19 @@ class TestPointHistBinsExplicit(_HistTestBase):
             self._gradient, "--point", "histogram", "--hist-bins", "0,25,50,75,100"
         )
         struct_type = table.schema.field("band_1").type
-        self.assertEqual(struct_type.field("values").type, pa.list_(pa.float64()))
+        self.assertEqual(struct_type.field("left").type, pa.list_(pa.float64()))
+        self.assertEqual(struct_type.field("right").type, pa.list_(pa.float64()))
         self.assertEqual(struct_type.field("counts").type, pa.list_(pa.int64()))
 
-    def test_bin_edges_are_lower_edges_of_populated_bins(self):
+    def test_bins_are_populated_bins_only(self):
         table = self._run(
             self._gradient, "--point", "histogram", "--hist-bins", "0,25,50,75,100"
         )
         for hist in self._non_null_histograms(table):
-            for v in hist["values"]:
-                self.assertIn(v, (0.0, 25.0, 50.0, 75.0))
+            for left, right in zip(hist["left"], hist["right"]):
+                self.assertIn(left, (0.0, 25.0, 50.0, 75.0))
+                self.assertIn(right, (25.0, 50.0, 75.0, 100.0))
+                self.assertEqual(right - left, 25.0)
 
     def test_nothing_dropped_when_bins_cover_full_range(self):
         table = self._run(
@@ -86,18 +142,23 @@ class TestPointHistBinsExplicit(_HistTestBase):
         # A value exactly at the final edge (99 is the max value; use an edge
         # that lands exactly on a present value) must be included, not dropped.
         table = self._run(self._gradient, "--point", "histogram", "--hist-bins", "0,99")
-        total = sum(sum(hist["counts"]) for hist in self._non_null_histograms(table))
+        histograms = self._non_null_histograms(table)
+        total = sum(sum(hist["counts"]) for hist in histograms)
         # Values 0..98 fall in [0, 99); value 99 must also be counted (closed
         # last bin), so nothing in range [0, 99] is dropped.
         self.assertEqual(total, _SIZE * _SIZE)
+        for hist in histograms:
+            for right in hist["right"]:
+                self.assertEqual(right, 99.0)
 
 
 class TestPointHistWidth(_HistTestBase):
     def test_edges_match_origin_plus_k_width(self):
         table = self._run(self._gradient, "--point", "histogram", "--hist-width", "25")
         for hist in self._non_null_histograms(table):
-            for v in hist["values"]:
-                self.assertEqual(v % 25, 0.0)
+            for left, right in zip(hist["left"], hist["right"]):
+                self.assertEqual(left % 25, 0.0)
+                self.assertEqual(right - left, 25.0)
 
     def test_width_mode_drops_nothing(self):
         table = self._run(self._gradient, "--point", "histogram", "--hist-width", "25")
@@ -117,15 +178,15 @@ class TestPointHistWidth(_HistTestBase):
             "--hist-origin",
             "10",
         )
-        default_edges = {
-            v for h in self._non_null_histograms(default_table) for v in h["values"]
+        default_lefts = {
+            left for h in self._non_null_histograms(default_table) for left in h["left"]
         }
-        shifted_edges = {
-            v for h in self._non_null_histograms(shifted_table) for v in h["values"]
+        shifted_lefts = {
+            left for h in self._non_null_histograms(shifted_table) for left in h["left"]
         }
-        self.assertNotEqual(default_edges, shifted_edges)
-        for edge in shifted_edges:
-            self.assertEqual((edge - 10) % 25, 0.0)
+        self.assertNotEqual(default_lefts, shifted_lefts)
+        for left in shifted_lefts:
+            self.assertEqual((left - 10) % 25, 0.0)
 
     def test_bins_and_width_mutually_exclusive(self):
         result = CliRunner().invoke(
@@ -159,23 +220,28 @@ class TestPointHistNormalize(_HistTestBase):
             "none",
         )
         struct_type = table.schema.field("band_1").type
-        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.float64()))
+        self.assertEqual(struct_type.field("count_frac").type, pa.list_(pa.float64()))
         for hist in self._non_null_histograms(table):
-            self.assertAlmostEqual(sum(hist["counts"]), 1.0, places=6)
+            self.assertAlmostEqual(sum(hist["count_frac"]), 1.0, places=6)
 
-    def test_cell_area_normalize_gives_positive_floats(self):
-        table = self._run(
-            self._gradient,
-            "--point",
-            "histogram",
-            "--hist-normalize",
-            "cell-area",
-            "-d",
-            "none",
+    def test_count_weight_with_cell_area_normalize_is_rejected(self):
+        # count + cell-area is a density (pixels/m^2), not a count or a
+        # fraction -- disallowed rather than given a misleading name.
+        result = CliRunner().invoke(
+            cli,
+            [
+                "h3",
+                str(self._gradient),
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_RES),
+                "--point",
+                "histogram",
+                "--hist-normalize",
+                "cell-area",
+            ],
         )
-        for hist in self._non_null_histograms(table):
-            for c in hist["counts"]:
-                self.assertGreater(c, 0.0)
+        self.assertNotEqual(result.exit_code, 0)
 
 
 class TestOverlayHistBinned(_HistTestBase):
@@ -229,7 +295,7 @@ class TestOverlayHistAreaWeight(_HistTestBase):
         self.assertNotEqual(result.exit_code, 0)
 
     def test_area_weighted_totals_conserve_raster_area(self):
-        # Summed across every cell the raster overlaps, area-weighted counts
+        # Summed across every cell the raster overlaps, area-weighted values
         # (coverage x geodesic pixel area) must reconstruct the raster's own
         # total geodesic area -- nothing gained or lost by partitioning across
         # H3 cells.
@@ -243,18 +309,16 @@ class TestOverlayHistAreaWeight(_HistTestBase):
             "none",
         )
         struct_type = table.schema.field("band_1").type
-        self.assertEqual(struct_type.field("counts").type, pa.list_(pa.float64()))
-        total_area = sum(
-            sum(hist["counts"]) for hist in self._non_null_histograms(table)
-        )
+        self.assertEqual(struct_type.field("area").type, pa.list_(pa.float64()))
+        total_area = sum(sum(hist["area"]) for hist in self._non_null_histograms(table))
         # Independently computed geodesic area of the (uniform, single-valued)
         # raster: bounds (174.0,-41.1)-(174.1,-41.0) is about 93.4 km^2.
         self.assertAlmostEqual(total_area, 93_365_567.0, delta=50_000.0)
 
     def test_area_weight_and_cell_area_normalize_matches_fractions(self):
-        # struct<values,counts> from an area-weighted, cell-area-normalized
-        # histogram on a single-valued raster should give ~ the same
-        # class-fraction as --overlay fractions for that (only) class.
+        # area_frac from an area-weighted, cell-area-normalized histogram on a
+        # single-valued raster should give ~ the same class-fraction as
+        # --overlay fractions for that (only) class.
         hist_table = self._run(
             self._uniform,
             "--overlay",
@@ -267,6 +331,12 @@ class TestOverlayHistAreaWeight(_HistTestBase):
             "none",
         )
         frac_table = self._run(self._uniform, "--overlay", "fractions", "-d", "none")
+
+        struct_type = hist_table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("area_frac").type, pa.list_(pa.float64()))
+        for c in self._non_null_histograms(hist_table):
+            for v in c["area_frac"]:
+                self.assertGreater(v, 0.0)
 
         hist_by_cell = dict(
             zip(hist_table.to_pandas().index, hist_table.to_pandas()["band_1"])
@@ -281,6 +351,8 @@ class TestOverlayHistAreaWeight(_HistTestBase):
             frac = frac_by_cell.get(cell_id)
             if frac is None:
                 continue
-            self.assertAlmostEqual(hist["counts"][0], frac["fractions"][0], delta=0.02)
+            self.assertAlmostEqual(
+                hist["area_frac"][0], frac["fractions"][0], delta=0.02
+            )
             compared += 1
         self.assertGreater(compared, 0)

--- a/tests/classes/test_output_schema.py
+++ b/tests/classes/test_output_schema.py
@@ -905,6 +905,22 @@ class TestOverlayCollect(TestRunthrough):
                 for c in row["counts"]:
                     self.assertGreater(c, 0, "Histogram count must be positive")
 
+    def test_overlay_list_no_decimals_does_not_crash(self):
+        # Regression test: _build_write_schema/_element_type used to resolve
+        # the "preserve source dtype" (-d none) branch against the Stage-2
+        # (post-aggregation) column dtype, which is `object` for collected
+        # list/histogram columns rather than the source raster's pixel
+        # dtype -- crashing pa.from_numpy_dtype. Fixed by capturing the real
+        # per-band dtypes at Stage 1 (kwargs["source_pixel_dtypes"]).
+        table = self._run_list("-d", "none")
+        field = table.schema.field("band_1")
+        self.assertEqual(field.type.value_type, pa.float32())
+
+    def test_overlay_histogram_no_decimals_does_not_crash(self):
+        table = self._run_histogram("-d", "none")
+        struct_type = table.schema.field("band_1").type
+        self.assertEqual(struct_type.field("values").type, pa.list_(pa.float32()))
+
     def test_overlay_list_and_histogram_same_total_values(self):
         list_table = self._run_list()
         hist_table = self._run_histogram()


### PR DESCRIPTION
Closes #68. `--point histogram`/`--overlay histogram` previously only counted exact pixel values, which is meaningless for continuous data (elevation, temperature — every pixel likely has a distinct value).

## New flags

- `--hist-bins EDGE,EDGE[,...]` — explicit ascending bin edges (e.g. `0,10,20,50`). Half-open `[a,b)`, last bin closed, out-of-range values dropped (`-inf`/`inf` for open-ended catch-all bins).
- `--hist-width FLOAT` (+ `--hist-origin FLOAT`) — uniform-width bins, unbounded, nothing dropped.
- `--hist-weight [count|area]` — `area` weights each pixel by its overlap area in m² (`--overlay histogram` only, reuses the existing geodesic pixel-area-weights machinery from `density-preserve`).
- `--hist-normalize [none|cell-area|valid-overlap]` — divide by the DGGS cell's own area, or by total valid contributing weight.

With none of these flags set, output is unchanged (same exact-value histogram as before).

## Output schema

Binned output reports each populated bin's own bounds directly (`left`/`right` parallel arrays), not just a lower edge, so a row is interpretable without external context. The weight field is named for what it actually contains (`counts`, `count_frac`, `area`, `area_frac`, `area_share` depending on the weight/normalize combination) rather than a single, sometimes-misleading fixed name. `count` + `cell-area` is rejected (a pixel count divided by area is a density, not a useful count or fraction). Binning config is also recorded as Parquet schema metadata (`raster2dggs:histogram` key).

All new logic lives in a shared `raster2dggs/histogram.py` module used by both `--point histogram` and `--overlay histogram`.

## Also fixes two pre-existing bugs found while building this

- `parent_groupby_nn`'s `.astype("Int64")` ran on the whole (object-dtype) frame for `decimals <= 0`, crashing for `--overlay list`/`histogram` output.
- `_build_write_schema` used the Stage-2 (post-aggregation) column dtype instead of the source raster's pixel dtype for `--overlay list`/`histogram -d none`, which is `object` after aggregation and crashed `pa.from_numpy_dtype`. Fixed by capturing the real per-band dtypes at Stage 1.

## Test plan

- [x] `pytest` — full suite passes (333 passed, 16 skipped — skips are optional DGGS extras not installed locally)
- [x] New `tests/classes/test_histogram_binning.py`: explicit/width binning, out-of-range dropping, last-bin-closed, normalization modes, area-weight totals conserve raster area (cross-checked against `--overlay fractions`), the two regression fixes above, weight-field-naming unit tests
- [x] Manually verified against a real ~48M-pixel DEM (`--overlay histogram --hist-bins ... --hist-weight area --hist-normalize valid-overlap --geo polygon`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)