### PR TITLE
Fix A5 --overlay crashes under threading: serialise pya5 access, closes #73

### DIFF
--- a/raster2dggs/indexers/a5rasterindexer.py
+++ b/raster2dggs/indexers/a5rasterindexer.py
@@ -2,6 +2,9 @@
 @author: ndemaio
 """
 
+import functools
+import threading
+
 import a5 as a5py
 import numpy as np
 import pandas as pd
@@ -10,12 +13,30 @@ import shapely
 import raster2dggs.constants as const
 from raster2dggs.indexers.rasterindexer import RasterIndexer
 
+# pya5 keeps unlocked module-level mutable state (e.g. a single-entry cache of
+# the last resolved cell, used to speed up dense-sample loops) and is not
+# thread-safe. raster2dggs calls into it from multiple threads (per-window in
+# Stage 1, per-partition in Stage 2's dask map_partitions), so every entry
+# point into a5py is serialised through this lock. Reentrant because some
+# methods below call each other (e.g. valid_set -> is_valid_a5_cell).
+_A5_LOCK = threading.RLock()
+
+
+def _locked(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _A5_LOCK:
+            return fn(*args, **kwargs)
+
+    return wrapper
+
 
 class A5RasterIndexer(RasterIndexer):
     """
     Provides integration for the A5 DGGS.
     """
 
+    @_locked
     def _index_window(self, wide, resolution: int, parent_res: int):
         # pya5 has no batch lonlat_to_cell API, so this is a per-point loop
         # (~200us/point).
@@ -34,6 +55,7 @@ class A5RasterIndexer(RasterIndexer):
         return wide
 
     @staticmethod
+    @_locked
     def cell_to_children_size(cell: int, desired_resolution: int) -> int:
         """
         Determine total number of children at some offset resolution
@@ -43,6 +65,7 @@ class A5RasterIndexer(RasterIndexer):
         cell_level = a5py.get_resolution(cell)
         return a5py.get_num_children(cell_level, desired_resolution)
 
+    @_locked
     def valid_set(self, cells: set) -> set[str]:
         """
         Implementation of interface function.
@@ -58,18 +81,24 @@ class A5RasterIndexer(RasterIndexer):
         )
 
     @staticmethod
+    @_locked
     def parent_cells(cells: set, resolution) -> map:
         """
         Implementation of interface function.
         """
-        return map(
-            a5py.u64_to_hex,
+        # Materialised eagerly (not a lazy map) so the a5py calls happen while
+        # the lock is held, rather than later when the caller consumes it.
+        return list(
             map(
-                lambda x: a5py.cell_to_parent(x, resolution),
-                map(a5py.hex_to_u64, cells),
-            ),
+                a5py.u64_to_hex,
+                map(
+                    lambda x: a5py.cell_to_parent(x, resolution),
+                    map(a5py.hex_to_u64, cells),
+                ),
+            )
         )
 
+    @_locked
     def expected_count(self, parent: str, resolution: int):
         """
         Implementation of interface function.
@@ -77,6 +106,7 @@ class A5RasterIndexer(RasterIndexer):
         return self.cell_to_children_size(a5py.hex_to_u64(parent), resolution)
 
     @staticmethod
+    @_locked
     def is_valid_a5_cell(cell: str) -> bool:
         """
         Returns cell validity.
@@ -94,6 +124,7 @@ class A5RasterIndexer(RasterIndexer):
 
     SUPPORTS_CELL_ENUMERATION: bool = True
 
+    @_locked
     def cells_in_bbox(
         self,
         min_lon: float,
@@ -121,6 +152,7 @@ class A5RasterIndexer(RasterIndexer):
         cells = a5py.uncompact(compacted, resolution)
         return {a5py.u64_to_hex(c) for c in cells}
 
+    @_locked
     def cell_area_m2(self, resolution: int, lat: float, lon: float) -> float:
         # A5 is equal-area: every cell at a given resolution has the same area,
         # so lat/lon are unused. Subdivision is aperture 5 from resolution 0 to
@@ -129,6 +161,7 @@ class A5RasterIndexer(RasterIndexer):
         return a5py.cell_area(resolution)
 
     @staticmethod
+    @_locked
     def cells_to_lonlat_arrays(cells: pd.Series) -> tuple[np.ndarray, np.ndarray]:
         # a5py.cell_to_lonlat returns (lon, lat) directly
         pts = np.array([a5py.cell_to_lonlat(a5py.hex_to_u64(c)) for c in cells])
@@ -138,6 +171,7 @@ class A5RasterIndexer(RasterIndexer):
         return lons, lats
 
     @staticmethod
+    @_locked
     def cell_to_point(cell: str) -> shapely.geometry.Point:
         cell_u64 = a5py.hex_to_u64(cell)
         lon, lat = a5py.cell_to_lonlat(cell_u64)
@@ -145,6 +179,7 @@ class A5RasterIndexer(RasterIndexer):
         return shapely.Point(lon, lat)
 
     @staticmethod
+    @_locked
     def cell_to_polygon(cell: str) -> shapely.geometry.Polygon:
         cell = a5py.hex_to_u64(cell)
         return shapely.Polygon(tuple(a5py.cell_to_boundary(cell)))

--- a/tests/regression/test_a5_thread_safety.py
+++ b/tests/regression/test_a5_thread_safety.py
@@ -1,0 +1,130 @@
+"""
+Regression test for a concurrency crash in A5 --overlay processing.
+
+Background: pya5 (raster2dggs/indexers/a5rasterindexer.py) keeps unlocked
+module-level mutable state (a single-entry cache of the last resolved cell,
+used to speed up dense-sample loops). raster2dggs calls into it from multiple
+threads -- per-window in Stage 1, per-partition in Stage 2's dask
+map_partitions -- with no serialisation. Under real multi-threaded load this
+produced a reproducible crash: `cells_in_bbox` -> `a5.polygon_to_cells` ->
+`cell_to_spherical` -> `equal_area.inverse` -> `math.acos(...)` raising
+`ValueError: math domain error`, from mismatched/torn state read across
+threads. Confirmed via the actual reported repro command: consistently
+crashed multi-threaded, never crashed single-threaded (`--threads 1`).
+
+Reproducing the exact race reliably in a fast test is impractical (it is
+timing-dependent, and synthetic concurrent-call stress tests did not trigger
+it in isolation during investigation, even though the real pipeline did).
+Instead, this test verifies the actual fix mechanism directly: every
+A5RasterIndexer method that calls into a5py acquires raster2dggs's own
+`_A5_LOCK` first, so pya5 never sees concurrent entry regardless of how many
+threads raster2dggs itself uses.
+"""
+
+import threading
+
+import pandas as pd
+import pytest
+
+try:
+    import a5
+
+    import raster2dggs.indexers.a5rasterindexer as a5mod
+except ImportError:
+    pytest.skip("a5 extra not installed", allow_module_level=True)
+
+
+def _lock_held_by_caller() -> bool:
+    """True iff _A5_LOCK is currently held by the calling thread (checked by
+    trying to acquire it, without blocking, from a *different* thread)."""
+    result = {}
+
+    def checker():
+        acquired = a5mod._A5_LOCK.acquire(blocking=False)
+        result["acquired"] = acquired
+        if acquired:
+            a5mod._A5_LOCK.release()
+
+    t = threading.Thread(target=checker)
+    t.start()
+    t.join()
+    return not result["acquired"]
+
+
+@pytest.fixture
+def indexer():
+    return a5mod.A5RasterIndexer("a5")
+
+
+@pytest.fixture
+def assert_locked_during(monkeypatch):
+    """Patches the given a5py attribute so that, while it runs, _A5_LOCK must
+    already be held by the calling thread."""
+    checked = []
+
+    def _apply(attr_name):
+        original = getattr(a5mod.a5py, attr_name)
+
+        def wrapper(*args, **kwargs):
+            checked.append(attr_name)
+            assert (
+                _lock_held_by_caller()
+            ), f"a5py.{attr_name} was called without _A5_LOCK held"
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(a5mod.a5py, attr_name, wrapper)
+
+    yield _apply
+    assert checked, "patched a5py attribute was never actually called"
+
+
+def test_cells_in_bbox_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("polygon_to_cells")
+    indexer.cells_in_bbox(170.0, -41.0, 171.0, -40.0, 6)
+
+
+def test_index_window_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("lonlat_to_cell")
+    wide = pd.DataFrame({"x": [170.5, 170.6], "y": [-40.5, -40.6]})
+    indexer._index_window(wide, resolution=6, parent_res=2)
+
+
+def test_cell_area_m2_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("cell_area")
+    indexer.cell_area_m2(6, -40.5, 170.5)
+
+
+def test_valid_set_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("get_resolution")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    indexer.valid_set({cell})
+
+
+def test_parent_cells_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("cell_to_parent")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    list(indexer.parent_cells({cell}, 2))
+
+
+def test_expected_count_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("hex_to_u64")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    indexer.expected_count(cell, 8)
+
+
+def test_cells_to_lonlat_arrays_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("cell_to_lonlat")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    indexer.cells_to_lonlat_arrays(pd.Series([cell]))
+
+
+def test_cell_to_point_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("cell_to_lonlat")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    indexer.cell_to_point(cell)
+
+
+def test_cell_to_polygon_holds_lock(indexer, assert_locked_during):
+    assert_locked_during("cell_to_boundary")
+    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    indexer.cell_to_polygon(cell)


### PR DESCRIPTION
## Summary
Stacked on #75 (same file, builds on that fix).

- `pya5` keeps an unlocked, module-level mutable cache (`a5/core/cell.py`'s `_last_result`), read/written via multiple non-atomic statements. raster2dggs calls into it from multiple threads (Stage 1 `ThreadPoolExecutor`, Stage 2 dask `map_partitions`), which produced an intermittent `ValueError: math domain error` deep inside pya5's equal-area projection inverse.
- Found while manually re-verifying #72's fix against the original reported repro (`-r 15`, default thread count).
- Confirmed via the repro itself: crashed reliably multi-threaded (same traceback shape, different specific cell each time -- consistent with a race), never crashed across a full run at `--threads 1`.
- Fix: serialise every entry point into `a5py` behind a module-level `threading.RLock()`.

Accepted trade-off: A5-specific CPU work becomes effectively single-threaded (on top of the already-accepted `_index_window` cost from #72). Preserves I/O overlap for the surrounding GDAL/rasterio work; pure Python doesn't release the GIL during pya5 calls anyway, so true parallelism wasn't happening there regardless.

## Test plan
- [x] The exact crashing command re-run three times post-fix: two completed cleanly end to end, the third ran crash-free well past the original ~22%-through crash point before an unrelated wall-clock budget cut it off.
- [x] `tests/regression/test_a5_thread_safety.py` (new): locks in the locking mechanism itself (confirmed it actually detects a missing lock via a throwaway unlocked stand-in, not just passing vacuously) rather than chasing the underlying race directly, which proved impractical to reproduce reliably in a fast synthetic test.
- [x] Full suite passes, `black`-clean.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)