### PR TITLE
Add CI job to actually run the test suite, plus a black check, closes #80

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
 
     steps:
       - name : 'Checkout'
-        uses : 'actions/checkout@v2'
+        uses : 'actions/checkout@v7'
       - name : 'manaakiwhenua-standards'
         uses : manaakiwhenua/manaakiwhenua-standards@v0.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -24,7 +24,7 @@ jobs:
       - name: Build distributions
         run: poetry build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -37,7 +37,7 @@ jobs:
       id-token: write  # required for OIDC trusted publisher
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,11 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    uses: ./.github/workflows/run-tests.yml
+
   build:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,36 @@
+name: run-tests
+
+on:
+  workflow_call:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up conda environment with GDAL 3.13.1
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          python-version: "3.12"
+          channels: conda-forge
+          channel-priority: strict
+          conda-remove-defaults: true
+
+      - name: Install GDAL from conda-forge
+        run: conda install -y gdal=3.13.1 -c conda-forge
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev --all-extras
+
+      - name: Run test suite
+        run: |
+          export PROJ_DATA="$CONDA_PREFIX/share/proj"
+          poetry run python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,16 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up conda environment with GDAL 3.13.1
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           python-version: "3.12"
           channels: conda-forge
           channel-priority: strict
+          conda-remove-defaults: true
 
       - name: Install GDAL from conda-forge
         run: conda install -y gdal=3.13.1 -c conda-forge
@@ -39,9 +40,9 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: test
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up conda environment with GDAL 3.13.1
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          python-version: "3.12"
+          channels: conda-forge
+          channel-priority: strict
+
+      - name: Install GDAL from conda-forge
+        run: conda install -y gdal=3.13.1 -c conda-forge
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev --all-extras
+
+      - name: Run test suite
+        run: |
+          export PROJ_DATA="$CONDA_PREFIX/share/proj"
+          poetry run python -m pytest
+
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install black
+        run: pip install black
+
+      - name: Check formatting
+        run: black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,35 +7,7 @@ permissions:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up conda environment with GDAL 3.13.1
-        uses: conda-incubator/setup-miniconda@v4
-        with:
-          miniforge-version: latest
-          python-version: "3.12"
-          channels: conda-forge
-          channel-priority: strict
-          conda-remove-defaults: true
-
-      - name: Install GDAL from conda-forge
-        run: conda install -y gdal=3.13.1 -c conda-forge
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Install dependencies
-        run: poetry install --with dev --all-extras
-
-      - name: Run test suite
-        run: |
-          export PROJ_DATA="$CONDA_PREFIX/share/proj"
-          poetry run python -m pytest
+    uses: ./.github/workflows/run-tests.yml
 
   black:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -663,6 +663,8 @@ Please run `black .` before committing.
 
 #### Tests
 
+[![test](https://github.com/manaakiwhenua/raster2dggs/actions/workflows/test.yml/badge.svg)](https://github.com/manaakiwhenua/raster2dggs/actions/workflows/test.yml)
+
 Tests are included. To run them, set up a poetry environment, then run from the project root:
 
 ```bash


### PR DESCRIPTION
## Summary
- `.github/workflows/main.yml` runs only the reusable `manaakiwhenua-standards` action (README/license presence check). The full test suite has never run in CI, and `black` is never checked despite being a declared convention.
- New `run-tests.yml` (`workflow_call` reusable workflow): provisions a conda environment with `gdal=3.13.1` from conda-forge (mirroring the proven-working local dev recipe from CLAUDE.md, since a bare pip/poetry install fails against the runner's older system GDAL), installs via `poetry install --with dev --all-extras`, sets `PROJ_DATA` to the conda env's own proj data, and runs the full suite.
- `test.yml`: calls `run-tests.yml` for the `pytest` job, plus a separate `black` job needing no GDAL/conda at all.
- `publish.yml`: now also calls `run-tests.yml` as a `test` job, and `build` (hence `publish`, which needs `build`) now `needs: test` — a release can no longer publish to PyPI without the full suite passing first, using the *exact* same tested logic validated in `test.yml`'s own CI runs, not a duplicated copy that could drift.
- Bumped stale action versions across all three workflow files (`actions/checkout` v2/v4→v7, `actions/setup-python` v5→v7, `conda-incubator/setup-miniconda` v3→v4, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4→v8) — clears the Node 20 deprecation warnings. Also fixed a conda "defaults channel added implicitly" warning via `conda-remove-defaults: true`.
- Added a test-status badge to the README, matching the existing `black` badge's placement.
- Confirmed the whole repo is already `black`-clean before adding the check, so it won't fail on pre-existing formatting.

## Test plan
- [x] Watched every version of this workflow run live on this PR across several pushes (not just assumed it would work): initial `test.yml` (pytest 4m39s, black 15s), action-version bumps re-verified (pytest+black both green again), and the final reusable-workflow refactor re-verified once more (`pytest / pytest` 4m9s, `black` 10s) -- confirming the local `uses: ./.github/workflows/run-tests.yml` call resolves and runs correctly.
- [ ] `publish.yml`'s new `test` gate can't be exercised by a throwaway push (it only triggers on an actual published GitHub Release), so the next real release is the first live test of that specific path -- but it calls the identical reusable workflow already validated above, and the `upload-artifact`/`download-artifact` version bumps are the only pieces in that file not independently exercised this session.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)