### PR TITLE
Minor cleanups: typo, dead duplicate constant, set literal, LOGGER bypass, closes #82

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -178,7 +178,7 @@ def create_aggfuncs(
     result = []
     for name in names:
         if name == "mode":
-            logging.warning(
+            LOGGER.warning(
                 "Mode aggregation: arbitrary behaviour: if there is more than one mode when aggregating, only the first value will be recorded."
             )
             result.append((name, _mode))

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -16,10 +16,6 @@ MIN_ISEA9R, MAX_ISEA9R = (
     0,
     16,
 )
-MIN_ISEA9R, MAX_ISEA9R = (
-    0,
-    16,
-)
 MIN_ISEA3H, MAX_ISEA3H = (
     0,
     33,
@@ -36,10 +32,10 @@ MIN_IVEA4R, MAX_IVEA4R = (
     0,
     25,
 )
-MIN_IVEA9R, MAX_IVEA9R = {
+MIN_IVEA9R, MAX_IVEA9R = (
     0,
     16,
-}
+)
 MIN_IVEA3H, MAX_IVEA3H = (
     0,
     33,

--- a/raster2dggs/indexerfactory.py
+++ b/raster2dggs/indexerfactory.py
@@ -118,7 +118,7 @@ def indexer_instance(dggs: str) -> IRasterIndexer:
         module = import_module(module_name)
     except ModuleNotFoundError as e:
         raise ImportError(
-            f"Mising dependency '{e.name}' for backend '{dggs}'.\n"
+            f"Missing dependency '{e.name}' for backend '{dggs}'.\n"
             f"Install optional dependencies: pip install 'raster2dggs[{extra}]' "
             f"(or 'raster2dggs[all]')."
         ) from e


### PR DESCRIPTION
## Summary
Four small, unrelated cleanups noted during the full-codebase review, batched here since each is trivial:
- `indexerfactory.py:121` — typo "Mising dependency" -> "Missing dependency".
- `constants.py` — removed a dead duplicate `MIN_ISEA9R, MAX_ISEA9R` assignment (assigned twice identically).
- `constants.py` — `MIN_IVEA9R, MAX_IVEA9R` now a tuple, matching every other pair in the file, instead of a set literal.
- `common.py:180` — mode-aggregation warning now goes through the module `LOGGER` instead of root `logging`, so it respects `-v`/`click_log` verbosity control.

## Test plan
- [x] Confirmed no tests assert on the exact strings being changed.
- [x] Full suite passes, `black`-clean.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)