### PR TITLE
Parametrize cell_area_m2 and --overlay tests across all DGGS implementations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,6 @@ authors:
     given-names: Nicoletta
 repository-code: https://github.com/manaakiwhenua/raster2dggs
 url: https://github.com/manaakiwhenua/raster2dggs
-version: "0.14.3"
+version: "0.14.4"
 date-released: "2026-07-24"
 license: LGPL-3.0-or-later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "raster2dggs"
-version = "0.14.3"
+version = "0.14.4"
 description = ""
 authors = ["James Ardo <ardoj@landcareresearch.co.nz>"]
 maintainers = ["Richard Law <lawr@landcareresearch.co.nz>"]

--- a/tests/classes/test_overlay_cross_dggs.py
+++ b/tests/classes/test_overlay_cross_dggs.py
@@ -1,0 +1,127 @@
+"""
+Cross-DGGS tests for --overlay.
+
+test_output_schema.py's TestOverlay only ever instantiates H3 -- the same
+gap that let real bugs in rHEALPix/A5's cells_in_bbox (missing
+cos(latitude) correction) and DGGAL's cell_area_m2 (swapped GeoPoint args)
+ship unnoticed. --overlay's arithmetic depends on both, so it's worth
+checking directly rather than assuming H3 coverage transfers.
+
+Invariants are resolution-agnostic (true regardless of how many cells the
+small test raster spans), since exact per-DGGS coarse-resolution tuning
+(as test_output_schema.py's _COARSE_RES does for H3 specifically) isn't
+needed for them to hold: the source raster is uniform-valued, so an
+area-weighted mean of any subset of its pixels equals that value, and a
+mass-preserving sum over all output cells equals pixel_value * pixel_count
+regardless of how the cells are split.
+"""
+
+import pytest
+import rasterio
+from click.testing import CliRunner
+
+from classes.base import clear_folder
+from classes.helpers import make_raster
+from data.datapaths import TEST_OUTPUT_PATH
+from raster2dggs.cli import cli
+from raster2dggs.cli_factory import SPECS
+from raster2dggs.indexerfactory import INDEXER_LOOKUP
+
+_BOUNDS = (174.0, -41.1, 174.1, -41.0)
+_SIZE = 10
+_PIXEL_VALUE = 42.0
+
+_SPEC_BY_NAME = {s.name: s for s in SPECS}
+_RES_BY_DGGS = {"maidenhead": 3}
+_DEFAULT_RES = 6
+
+
+def _one_dggs_per_indexer_module():
+    """Same rationale as test_resolution_modes.py's TestCellAreaM2: one
+    representative per distinct indexer module, derived from
+    INDEXER_LOOKUP rather than hand-listed."""
+    seen_modules = set()
+    names = []
+    for name, (module_path, _class_name, _extra) in INDEXER_LOOKUP.items():
+        if module_path in seen_modules:
+            continue
+        seen_modules.add(module_path)
+        names.append(name)
+    return names
+
+
+_DGGS_NAMES = _one_dggs_per_indexer_module()
+
+
+def _safe_res(name):
+    spec = _SPEC_BY_NAME[name]
+    return max(spec.min_res, min(_RES_BY_DGGS.get(name, _DEFAULT_RES), spec.max_res))
+
+
+@pytest.fixture
+def uniform_raster(tmp_path):
+    path = tmp_path / "uniform.tif"
+    make_raster(str(path), _BOUNDS, _SIZE, pixel_value=_PIXEL_VALUE)
+    return str(path)
+
+
+@pytest.fixture(params=_DGGS_NAMES)
+def dggs_name(request):
+    return request.param
+
+
+def _run_overlay(dggs, raster_path, *overlay_flags, extra_args=()):
+    if TEST_OUTPUT_PATH.exists():
+        clear_folder(TEST_OUTPUT_PATH)
+    TEST_OUTPUT_PATH.mkdir(exist_ok=True)
+    result = CliRunner().invoke(
+        cli,
+        [
+            dggs,
+            raster_path,
+            str(TEST_OUTPUT_PATH),
+            "-r",
+            str(_safe_res(dggs)),
+            "--overlay",
+            *overlay_flags,
+            *extra_args,
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    import pyarrow.parquet as pq
+
+    return pq.read_table(str(TEST_OUTPUT_PATH))
+
+
+class TestOverlayCrossDGGS:
+    def test_overlay_weighted_matches_uniform_pixel_value(
+        self, dggs_name, uniform_raster
+    ):
+        try:
+            table = _run_overlay(dggs_name, uniform_raster, "weighted")
+        except ImportError:
+            pytest.skip(f"{dggs_name} extra not installed")
+        df = table.to_pandas()
+        assert not df.empty, f"{dggs_name}: --overlay weighted produced no rows"
+        vals = df["band_1"].dropna()
+        assert (
+            vals - _PIXEL_VALUE
+        ).abs().max() < 1e-2, (
+            f"{dggs_name}: expected ~{_PIXEL_VALUE}, got {vals.unique()}"
+        )
+
+    def test_overlay_mass_preserve_conserves_total(self, dggs_name, uniform_raster):
+        try:
+            table = _run_overlay(
+                dggs_name, uniform_raster, "mass-preserve", extra_args=("-d", "none")
+            )
+        except ImportError:
+            pytest.skip(f"{dggs_name} extra not installed")
+        cell_total = table.to_pandas()["band_1"].sum()
+        with rasterio.open(uniform_raster) as src:
+            raster_total = _PIXEL_VALUE * src.width * src.height
+        assert abs(cell_total - raster_total) < raster_total * 1e-3, (
+            f"{dggs_name}: mass_preserve total {cell_total:.6f} differs from "
+            f"raster total {raster_total:.6f}"
+        )

--- a/tests/classes/test_resolution_modes.py
+++ b/tests/classes/test_resolution_modes.py
@@ -1,10 +1,15 @@
+import importlib
+
+import pytest
 from click.testing import CliRunner
 
-from classes.base import TestRunthrough, TestCase
+from classes.base import TestRunthrough
 from classes.helpers import make_raster
 from data.datapaths import TEST_OUTPUT_PATH
 from raster2dggs.cli import cli
+from raster2dggs.cli_factory import SPECS
 from raster2dggs.constants import ResolutionMode
+from raster2dggs.indexerfactory import INDEXER_LOOKUP
 import raster2dggs.common as common
 from raster2dggs.indexers.h3rasterindexer import H3RasterIndexer
 
@@ -18,34 +23,70 @@ def _make_raster(path: str) -> None:
     make_raster(path, _BOUNDS, _SIZE, pixel_value=1.0)
 
 
-class TestCellAreaM2(TestCase):
-    """cell_area_m2 returns positive, monotonically decreasing values for H3."""
+def _one_dggs_per_indexer_module():
+    """One representative DGGS name per distinct indexer module, derived from
+    INDEXER_LOOKUP rather than hand-listed -- DGGAL's 16 grids all share one
+    module (and its cell_area_m2 implementation), so this collapses them to
+    a single representative automatically, and stays correct if the registry
+    changes. This is the exact function that had confirmed real bugs for
+    DGGAL (swapped GeoPoint(lon, lat) args) and A5 (aperture-4/5 mismatch at
+    resolution 0), both previously invisible here because this test only ever
+    instantiated H3RasterIndexer."""
+    seen_modules = set()
+    cases = []
+    for name, (module_path, class_name, _extra) in INDEXER_LOOKUP.items():
+        if module_path in seen_modules:
+            continue
+        seen_modules.add(module_path)
+        cases.append((name, module_path, class_name))
+    return cases
 
-    def setUp(self):
-        self.indexer = H3RasterIndexer("h3")
-        self.lat, self.lon = -41.05, 174.05
 
-    def test_positive_at_all_resolutions(self):
-        for res in range(_H3_MIN, _H3_MAX + 1):
-            area = self.indexer.cell_area_m2(res, self.lat, self.lon)
-            self.assertGreater(area, 0, f"H3 res {res} area must be positive")
+_SPEC_BY_NAME = {s.name: s for s in SPECS}
+_DGGS_CASES = _one_dggs_per_indexer_module()
 
-    def test_decreases_with_resolution(self):
+
+@pytest.fixture(params=_DGGS_CASES, ids=[c[0] for c in _DGGS_CASES])
+def cell_area_indexer(request):
+    dggs, module_path, class_name = request.param
+    try:
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+    except ImportError:
+        pytest.skip(f"{dggs} extra not installed")
+    spec = _SPEC_BY_NAME[dggs]
+    return cls(dggs), spec.min_res, spec.max_res
+
+
+class TestCellAreaM2:
+    """cell_area_m2 returns positive, monotonically decreasing values, for
+    every DGGS implementation (not just H3)."""
+
+    _lat, _lon = -41.05, 174.05
+
+    def test_positive_at_all_resolutions(self, cell_area_indexer):
+        indexer, min_res, max_res = cell_area_indexer
+        for res in range(min_res, max_res + 1):
+            area = indexer.cell_area_m2(res, self._lat, self._lon)
+            assert area > 0, f"{indexer.dggs} res {res} area must be positive"
+
+    def test_decreases_with_resolution(self, cell_area_indexer):
+        indexer, min_res, max_res = cell_area_indexer
         areas = [
-            self.indexer.cell_area_m2(res, self.lat, self.lon)
-            for res in range(_H3_MIN, _H3_MAX + 1)
+            indexer.cell_area_m2(res, self._lat, self._lon)
+            for res in range(min_res, max_res + 1)
         ]
         for i in range(len(areas) - 1):
-            self.assertGreater(
-                areas[i],
-                areas[i + 1],
-                f"H3 area should decrease from res {i} to res {i + 1}",
+            assert areas[i] > areas[i + 1], (
+                f"{indexer.dggs} area should decrease from res {min_res + i} "
+                f"to res {min_res + i + 1}"
             )
 
-    def test_coarsest_larger_than_finest(self):
-        coarsest = self.indexer.cell_area_m2(_H3_MIN, self.lat, self.lon)
-        finest = self.indexer.cell_area_m2(_H3_MAX, self.lat, self.lon)
-        self.assertGreater(coarsest, finest)
+    def test_coarsest_larger_than_finest(self, cell_area_indexer):
+        indexer, min_res, max_res = cell_area_indexer
+        coarsest = indexer.cell_area_m2(min_res, self._lat, self._lon)
+        finest = indexer.cell_area_m2(max_res, self._lat, self._lon)
+        assert coarsest > finest
 
 
 class TestComputePixelAreaM2(TestRunthrough):

--- a/tests/classes/test_resolution_modes.py
+++ b/tests/classes/test_resolution_modes.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 from click.testing import CliRunner
 
@@ -8,7 +6,8 @@ from classes.helpers import make_raster
 from data.datapaths import TEST_OUTPUT_PATH
 from raster2dggs.cli import cli
 from raster2dggs.cli_factory import SPECS
-from raster2dggs.constants import ResolutionMode
+from raster2dggs.constants import ResolutionMode, MIN_H3, MAX_H3
+import raster2dggs.indexerfactory as idxfactory
 from raster2dggs.indexerfactory import INDEXER_LOOKUP
 import raster2dggs.common as common
 from raster2dggs.indexers.h3rasterindexer import H3RasterIndexer
@@ -16,7 +15,6 @@ from raster2dggs.indexers.h3rasterindexer import H3RasterIndexer
 # Small single-band WGS84 raster — pixel size ≈ 0.01° × 0.01° near Auckland
 _BOUNDS = (174.0, -41.1, 174.1, -41.0)  # (left, bottom, right, top)
 _SIZE = 10  # 10 × 10 pixels
-_H3_MIN, _H3_MAX = 0, 15
 
 
 def _make_raster(path: str) -> None:
@@ -33,29 +31,28 @@ def _one_dggs_per_indexer_module():
     resolution 0), both previously invisible here because this test only ever
     instantiated H3RasterIndexer."""
     seen_modules = set()
-    cases = []
-    for name, (module_path, class_name, _extra) in INDEXER_LOOKUP.items():
+    names = []
+    for name, (module_path, _class_name, _extra) in INDEXER_LOOKUP.items():
         if module_path in seen_modules:
             continue
         seen_modules.add(module_path)
-        cases.append((name, module_path, class_name))
-    return cases
+        names.append(name)
+    return names
 
 
 _SPEC_BY_NAME = {s.name: s for s in SPECS}
-_DGGS_CASES = _one_dggs_per_indexer_module()
+_DGGS_NAMES = _one_dggs_per_indexer_module()
 
 
-@pytest.fixture(params=_DGGS_CASES, ids=[c[0] for c in _DGGS_CASES])
+@pytest.fixture(params=_DGGS_NAMES)
 def cell_area_indexer(request):
-    dggs, module_path, class_name = request.param
+    dggs = request.param
     try:
-        mod = importlib.import_module(module_path)
-        cls = getattr(mod, class_name)
+        indexer = idxfactory.indexer_instance(dggs)
     except ImportError:
         pytest.skip(f"{dggs} extra not installed")
     spec = _SPEC_BY_NAME[dggs]
-    return cls(dggs), spec.min_res, spec.max_res
+    return indexer, spec.min_res, spec.max_res
 
 
 class TestCellAreaM2:
@@ -129,7 +126,7 @@ class TestResolveModeInvariants(TestRunthrough):
         self.pixel_area, self.clat, self.clon = common.compute_pixel_area_m2(self._tmp)
 
     def _resolve(self, mode):
-        return common.resolve_resolution_mode(mode, "h3", self._tmp, _H3_MIN, _H3_MAX)
+        return common.resolve_resolution_mode(mode, "h3", self._tmp, MIN_H3, MAX_H3)
 
     def _cell_area(self, res):
         return self.indexer.cell_area_m2(res, self.clat, self.clon)
@@ -144,7 +141,7 @@ class TestResolveModeInvariants(TestRunthrough):
 
     def test_smaller_than_pixel_predecessor_is_larger(self):
         res = self._resolve("smaller-than-pixel")
-        if res > _H3_MIN:
+        if res > MIN_H3:
             self.assertGreater(
                 self._cell_area(res - 1),
                 self.pixel_area,
@@ -161,7 +158,7 @@ class TestResolveModeInvariants(TestRunthrough):
 
     def test_larger_than_pixel_successor_is_smaller(self):
         res = self._resolve("larger-than-pixel")
-        if res < _H3_MAX:
+        if res < MAX_H3:
             self.assertLess(
                 self._cell_area(res + 1),
                 self.pixel_area,
@@ -180,7 +177,7 @@ class TestResolveModeInvariants(TestRunthrough):
     def test_min_diff_minimises_area_difference(self):
         res = self._resolve("min-diff")
         best_diff = abs(self._cell_area(res) - self.pixel_area)
-        for other_res in range(_H3_MIN, _H3_MAX + 1):
+        for other_res in range(MIN_H3, MAX_H3 + 1):
             if other_res == res:
                 continue
             self.assertLessEqual(
@@ -194,8 +191,8 @@ class TestResolveModeInvariants(TestRunthrough):
         for mode in ResolutionMode:
             with self.subTest(mode=mode):
                 res = self._resolve(mode)
-                self.assertGreaterEqual(res, _H3_MIN)
-                self.assertLessEqual(res, _H3_MAX)
+                self.assertGreaterEqual(res, MIN_H3)
+                self.assertLessEqual(res, MAX_H3)
 
 
 class TestResolutionModeCLI(TestRunthrough):


### PR DESCRIPTION
Addresses the "Process gaps" item in CLAUDE.md: `cell_area_m2`/resolution-mode and `--overlay` tests were H3-only, which is exactly the kind of gap that let three real bugs (DGGAL's swapped `GeoPoint` args, A5's and rHEALPix's missing `cos(latitude)` correction) ship unnoticed until found separately, one at a time.

## What changed

- **`TestCellAreaM2`** (`test_resolution_modes.py`): now parametrized across one representative DGGS per distinct indexer implementation, instead of only ever instantiating `H3RasterIndexer`.
- **New `test_overlay_cross_dggs.py`**: two resolution-agnostic invariants (area-weighted mean matches a uniform raster's value; `mass-preserve` conserves the total) across the same representative set, since `test_output_schema.py`'s `TestOverlay` is H3-only too.

Representative set: one DGGS name per distinct indexer *module*, derived from `indexerfactory.INDEXER_LOOKUP` rather than hand-listed (DGGAL's 16 grids share one module/implementation, so this collapses them to a single representative — `isea4r` — automatically, and can't drift out of sync if the registry changes). Matches the same pattern `test_cells_in_bbox.py` already established for `cells_in_bbox`/`cells_to_lonlat_arrays`.

## Test plan

- [x] `pytest` — full suite passes (405 passed, 16 skipped)
- [x] New/changed tests verified directly: 21 parametrized `cell_area_m2` cases + 14 cross-DGGS `--overlay` cases, all passing across h3/rhp/geohash/maidenhead/s2/a5/isea4r

🤖 Generated with [Claude Code](https://claude.com/claude-code)