### PR TITLE
Fix band mislabeling when a band is entirely nodata within a window, closes #88

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -911,6 +911,7 @@ def initial_index(
                         parent_res=parent_res,
                         nodata=nodata,
                         selected_labels=selected_labels,
+                        selected_indices=tuple(selected_indices),
                         nodata_policy=nodata_policy,
                         emit_nodata_value=emit_nodata_value,
                         transformer=transformer,

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -113,6 +113,7 @@ class RasterIndexer(IRasterIndexer):
         nodata_policy: str = "omit",
         emit_nodata_value: Number | None = None,
         transformer=None,
+        selected_indices: tuple[int] = None,
     ) -> pa.Table:
         sdf: pd.DataFrame = (
             sdf.to_dataframe().drop(columns=["spatial_ref"]).reset_index()
@@ -142,9 +143,17 @@ class RasterIndexer(IRasterIndexer):
         wide = self._index_window(wide, resolution, parent_res)
         bands = sorted(sdf["band"].unique())
         if band_labels is None:
-            band_labels = tuple(str(b) for b in bands)
-        # Known bug (#88): positional pairing can mislabel bands when a window drops one.
-        wide = wide.rename(columns=dict(zip(bands, band_labels)))  # noqa: B905
+            rename_map = {b: str(b) for b in bands}
+        else:
+            # Map by band index, not position: bands present in this window
+            # can be a strict subset of selected_indices (e.g. a band
+            # that's entirely nodata within this window), so band_labels
+            # can't be zipped against `bands` directly without risking a
+            # silent off-by-one mislabeling of every band after a dropped
+            # one (#88).
+            full_mapping = dict(zip(selected_indices, band_labels, strict=True))
+            rename_map = {b: full_mapping[b] for b in bands if b in full_mapping}
+        wide = wide.rename(columns=rename_map)
         return pa.Table.from_pandas(wide, preserve_index=False)
 
     def cells_to_lonlat_arrays(self, cells: pd.Series) -> tuple[np.ndarray, np.ndarray]:

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -75,9 +75,17 @@ class IRasterIndexer:
         nodata_policy: str = "omit",
         emit_nodata_value: Number | None = None,
         transformer=None,
+        selected_indices: tuple[int] = None,
     ) -> pa.Table:
         """
         Function for primary indexation.
+
+        selected_indices must be given whenever band_labels is (and must be
+        the same length): it's the raster band index each label corresponds
+        to, used to rename output columns by band index rather than by
+        position, since a window can have fewer bands present than were
+        globally selected (e.g. a band that's entirely nodata within this
+        window).
         """
         raise NotImplementedError()
 

--- a/raster2dggs/transfers/assign_centers.py
+++ b/raster2dggs/transfers/assign_centers.py
@@ -30,6 +30,7 @@ class _AssignCentersIndexer:
     parent_res: int
     nodata: Any
     selected_labels: tuple
+    selected_indices: tuple
     nodata_policy: str
     emit_nodata_value: Any | None
     transformer: pyproj.Transformer
@@ -47,5 +48,6 @@ class _AssignCentersIndexer:
             nodata_policy=self.nodata_policy,
             emit_nodata_value=self.emit_nodata_value,
             transformer=self.transformer,
+            selected_indices=self.selected_indices,
         )
         self.write_result(result, window)

--- a/tests/regression/test_band_mislabel_nodata_gap.py
+++ b/tests/regression/test_band_mislabel_nodata_gap.py
@@ -1,0 +1,74 @@
+"""
+Regression test for issue #88: a band entirely nodata within one raster
+window could silently mislabel every later band's data under the wrong
+column name.
+
+Background: `RasterIndexer.index_func`'s `--nodata omit` (default) policy
+drops all-nodata rows from the working dataframe before computing which
+bands are actually present in this window (`bands = sorted(sdf["band"].
+unique())`). If an entire band is nodata within this window, it vanishes
+from `bands` -- but `band_labels` (the full, fixed set of globally
+selected bands) doesn't shrink to match. The old code paired the two
+positionally (`zip(bands, band_labels)`), so every band after the dropped
+one got shifted onto the wrong label.
+
+Fixed by pairing band_labels against selected_indices (the fixed, global
+band-index list they were built from) to get a {band_index: label}
+mapping, then applying that by band index rather than by position -- so a
+window with fewer bands present just renames fewer columns, instead of
+shifting the remaining ones.
+"""
+
+import numpy as np
+import rasterio
+from classes.base import TestRunthrough, read_output
+from data.datapaths import TEST_OUTPUT_PATH
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
+
+_BOUNDS = (174.0, -41.1, 174.1, -41.0)
+_SIZE = 4
+_NODATA = -9999.0
+_BAND_1_VALUE = 10.0
+_BAND_3_VALUE = 30.0
+
+
+def _make_raster_with_middle_band_nodata(path: str) -> None:
+    """3-band raster: band 1 and band 3 have real data; band 2 is entirely
+    nodata, so it's dropped entirely from the (--nodata omit default)
+    output -- reproducing the exact conditions of issue #88."""
+    data = np.empty((3, _SIZE, _SIZE), dtype=np.float32)
+    data[0] = _BAND_1_VALUE
+    data[1] = _NODATA
+    data[2] = _BAND_3_VALUE
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=_SIZE,
+        width=_SIZE,
+        count=3,
+        dtype="float32",
+        crs=CRS.from_epsg(4326),
+        transform=from_bounds(*_BOUNDS, _SIZE, _SIZE),
+        nodata=_NODATA,
+    ) as dst:
+        dst.write(data)
+
+
+class TestBandMislabelNodataGap(TestRunthrough):
+    def setUp(self):
+        super().setUp()
+        self._raster = self.make_temp_raster(_make_raster_with_middle_band_nodata)
+
+    def test_bands_are_not_mislabelled(self):
+        self.invoke_cli("h3", self._raster, TEST_OUTPUT_PATH, 4, "--agg", "mean")
+        table = read_output(TEST_OUTPUT_PATH)
+        df = table.to_pandas()
+
+        self.assertIn("band_1", df.columns)
+        self.assertIn("band_3", df.columns)
+        self.assertNotIn("band_2", df.columns)
+
+        self.assertTrue((df["band_1"] == _BAND_1_VALUE).all())
+        self.assertTrue((df["band_3"] == _BAND_3_VALUE).all())


### PR DESCRIPTION
Closes #88.

## Root cause

\`RasterIndexer.index_func\`'s column rename paired \`bands\` (this window's actual present bands, after \`--nodata omit\` drops all-nodata rows) against \`band_labels\` (the full, fixed set of globally selected bands) **positionally**:

\`\`\`python
bands = sorted(sdf["band"].unique())
...
wide = wide.rename(columns=dict(zip(bands, band_labels)))
\`\`\`

If a band is entirely nodata within one window, it vanishes from \`bands\` — but not from \`band_labels\`. The positional zip then silently shifts every band after the dropped one onto the wrong label, with no error.

## Fix

Thread \`selected_indices\` (the same fixed, global band-index list \`band_labels\` was built from) through to \`index_func\`, so the rename maps by **band index** instead of position: build a \`{band_index: label}\` mapping once from the two fixed-length lists (\`selected_indices\`, \`band_labels\` — safe to zip, always the same length by construction), then apply that mapping to whichever subset of bands is actually present in this window.

This required adding a \`selected_indices\` field to \`_AssignCentersIndexer\` (the \`--point\` transfer's context dataclass) and passing it through from \`common.py\`, matching the pattern \`_OverlayIndexer\` already used.

## Test plan

- [x] New regression test (\`tests/regression/test_band_mislabel_nodata_gap.py\`) reproduces the exact issue scenario (3-band raster, middle band entirely nodata)
- [x] **Verified the test actually catches the bug**: temporarily reverted the fix via \`git stash\`, ran the test, confirmed it fails with the exact symptom from the issue (band 3's data appearing under \`"band_2"\`, no \`"band_3"\` column at all) — then restored the fix and confirmed it passes
- [x] \`pytest\` — full suite passes (454 passed, 16 skipped)
- [x] \`ruff check .\` / \`black --check .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)