### PR TITLE
Fix --profile's parallelism figure: it reported ~7x on runs that were slower than --threads 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,28 +467,37 @@ Profile
   threads: 7
   windows: 2
 
-  phase                          seconds   % wall   calls   ms/call
-  -----------------------------------------------------------------
-  stage1.wall                      0.409    73.2%       1  409.461
-    window_total                   0.573   102.4%       2  286.420
-      read_block                   0.181    32.4%       2   90.662
-      reproject                    0.101    18.0%       2   50.352
-      reshape                      0.079    14.1%       2   39.392
-      dggs_index                   0.169    30.3%       2   84.663
-      arrow_build                  0.004     0.8%       2    2.180
-      parquet_write                0.022     4.0%       2   11.088
-  stage2.total                     0.038     6.9%       1   38.320
-  -----------------------------------------------------------------
-  wall clock                       0.559   100.0%
-  Stage 1 concurrency: 1.40x (0.573s of work in 0.409s wall)
+  pixels_read: 74,888
+  rows_indexed: 74,888
+  valid pixels: 100.0% of those read
+
+  phase                          seconds       cpu   % wall    calls     ms/call
+  ------------------------------------------------------------------------------
+  stage1.wall                      0.204     0.002    60.7%        1     203.643
+    window_total                   0.268     0.197    79.8%        2     133.845
+      read_block                   0.013     0.003     3.9%        2       6.525
+      reshape                      0.016     0.001     4.8%        2       8.000
+      reproject                    0.086     0.057    25.5%        2      42.818
+      build_frame                  0.001     0.001     0.2%        2       0.366
+      dggs_index                   0.122     0.121    36.3%        2      60.790
+      arrow_build                  0.003     0.002     1.0%        2       1.739
+      parquet_write                0.022     0.006     6.6%        2      11.077
+  stage2.total                     0.028     0.005     8.5%        1      28.475
+  ------------------------------------------------------------------------------
+  wall clock                       0.335             100.0%
+  Stage 1 parallelism: 0.97x (0.197s worker CPU in 0.204s wall)
+  Stage 1 thread stall: 26.5% (0.071s of 0.268s thread-time blocked)
+  ^ 7 threads are not paying for themselves here; compare against --threads 1
 ```
 
 Reading it:
 
 - **Indentation is nesting, not addition.** `read_block`, `dggs_index` and friends are measured *inside* `window_total`, which is itself measured inside `stage1.wall` — so those rows are a decomposition of their parent, not terms to be summed. Percentages are all of total wall clock.
-- **`stage1.wall` vs `window_total`** is the parallelism check. `window_total` sums across all worker threads, so it exceeds `stage1.wall` whenever threads genuinely overlapped; the **concurrency** figure at the bottom states the ratio directly. A value near `1.0x` with `--threads` > 1 means the threads achieved nothing — usually because that code path is holding the GIL or is serialised behind a lock.
+- **`seconds` is elapsed time; `cpu` is time actually spent computing.** Both are summed across whichever threads ran the phase. A phase where `cpu` is far below `seconds` was mostly *waiting* — for the GDAL read lock, or for the GIL. The two dispatcher rows are the exception: `stage1.wall` and `stage2.total` are measured in the main thread while the work happens in others, so their own `cpu` is near zero by construction.
+- **`Stage 1 parallelism`** is worker CPU per second of Stage 1 wall clock, i.e. how many cores' worth of work the thread pool actually achieved. It is deliberately *not* derived from summed worker elapsed time, because a blocked thread accumulates elapsed time just as a busy one does — that ratio rises towards the thread count exactly when the threads are achieving nothing. `Stage 1 thread stall` is the share of worker thread-time spent blocked rather than computing.
+- **Threading does not always pay.** If parallelism is well below 1.5x, the report says so. On paths that are GIL-bound (`--point`, whose DGGS indexing is a Python loop) or serialised behind the GDAL read lock, `--threads 1` can genuinely be *faster* than the default — worth measuring both ways on your own data rather than assuming more threads help.
 - **`ms/call` with `windows`** is what makes an unexpectedly slow run legible. A large window count with a small per-window cost points at the *input's* block layout rather than at the indexing work — check `block_shape` (a block height of 1 means the GeoTIFF is strip-encoded, giving one window per raster row) and see the [overlay performance note](#performance-note) for how to re-tile.
-- Profiling is off by default and the instrumentation is a single branch when disabled, so there is no reason to avoid it in normal use.
+- Profiling is off by default and the instrumentation is a single branch when disabled, so there is no reason to avoid it in normal use. The `cpu` column needs a per-thread CPU clock (Linux, Windows); where the platform has none, it and the two figures derived from it are omitted.
 
 ## Visualising output
 

--- a/raster2dggs/profiling.py
+++ b/raster2dggs/profiling.py
@@ -14,6 +14,13 @@ Usage:
 
 Disabled (the default), ``phase()`` returns a shared no-op context manager, so
 the cost on the normal path is one attribute check.
+
+Each phase records elapsed wall time *and* the CPU time of the thread that ran
+it. Both are needed: a thread blocked on the GDAL read lock or waiting for the
+GIL keeps accumulating wall time, so summed worker wall time approaches the
+thread count whenever threads are contending -- which is exactly when
+parallelism is absent. CPU time excludes blocked time, so it is the figure that
+can tell work apart from waiting.
 """
 
 from __future__ import annotations
@@ -26,6 +33,16 @@ from contextlib import contextmanager, nullcontext
 # Stateless and therefore safe to share across threads: __enter__/__exit__ do
 # nothing, so there is no per-use state to race on.
 _NULL_CONTEXT = nullcontext()
+
+# Per-thread CPU time. Documented as available on Linux and Windows, so treat
+# it as optional: without it the report simply omits the CPU column and the
+# figures derived from it.
+try:
+    time.thread_time()
+except (AttributeError, OSError):  # pragma: no cover - platform dependent
+    _THREAD_CPU = None
+else:
+    _THREAD_CPU = time.thread_time
 
 # Phases in pipeline order, with nesting depth. Depth matters for reading the
 # report correctly: inner phases are measured *inside* their parent, so their
@@ -52,20 +69,23 @@ _PHASE_DEPTH = dict(_PHASE_ORDER)
 
 
 class Profiler:
-    """Accumulates wall-clock time and call counts per named phase.
+    """Accumulates wall time, thread CPU time and call counts per named phase.
 
     Stage 1 calls into this from several worker threads at once. Updates and
     the ``report()`` snapshot are taken under a lock, which is what keeps the
     accumulator correct on free-threaded builds where the GIL does not.
 
-    Summed phase time exceeds the wall clock when worker threads overlap;
-    ``report()`` turns that into an explicit concurrency figure.
+    Summed phase wall time exceeds the elapsed wall clock when worker threads
+    overlap -- but also when they merely block, so ``report()`` derives its
+    parallelism figure from CPU time and reports the gap between the two as
+    stall.
     """
 
     def __init__(self) -> None:
         self.enabled: bool = False
         self._lock = threading.Lock()
         self._totals: dict[str, float] = defaultdict(float)
+        self._cpu: dict[str, float] = defaultdict(float)
         self._counts: dict[str, int] = defaultdict(int)
         self._context: dict[str, object] = {}
         self._counters: dict[str, int] = {}
@@ -81,6 +101,7 @@ class Profiler:
         with self._lock:
             self.enabled = enabled
             self._totals = defaultdict(float)
+            self._cpu = defaultdict(float)
             self._counts = defaultdict(int)
             self._context = {}
             self._counters = {}
@@ -101,12 +122,15 @@ class Profiler:
     @contextmanager
     def _timed(self, name: str):
         start = time.perf_counter()
+        cpu_start = _THREAD_CPU() if _THREAD_CPU else 0.0
         try:
             yield
         finally:
             elapsed = time.perf_counter() - start
+            cpu = (_THREAD_CPU() - cpu_start) if _THREAD_CPU else 0.0
             with self._lock:
                 self._totals[name] += elapsed
+                self._cpu[name] += cpu
                 self._counts[name] += 1
 
     def note(self, key: str, value) -> None:
@@ -128,6 +152,7 @@ class Profiler:
         """Render the collected measurements as a plain-text table."""
         with self._lock:
             totals = dict(self._totals)
+            cpu = dict(self._cpu)
             counts = dict(self._counts)
             context = dict(self._context)
             counters = dict(self._counters)
@@ -151,20 +176,30 @@ class Profiler:
                 lines.append(f"  valid pixels: {100 * kept / read:.1f}% of those read")
             lines.append("")
 
+        cpu_col = "cpu" if _THREAD_CPU else ""
         header = (
-            f"  {'phase':<28}{'seconds':>10}{'% wall':>9}{'calls':>9}{'ms/call':>12}"
+            f"  {'phase':<28}{'seconds':>10}{cpu_col:>10}"
+            f"{'% wall':>9}{'calls':>9}{'ms/call':>12}"
         )
         lines.append(header)
         lines.append(f"  {'-' * (len(header) - 2)}")
 
-        def row(label: str, seconds: float, calls: int | None) -> str:
+        def row(
+            label: str, seconds: float, thread_cpu: float | None, calls: int | None
+        ) -> str:
             pct = f"{100 * seconds / wall:>8.1f}%" if wall else "        -"
             if calls:
                 per_call = f"{1000 * seconds / calls:>12.3f}"
                 calls_s = f"{calls:>9}"
             else:
                 per_call, calls_s = "           -", "        -"
-            return f"  {label:<28}{seconds:>10.3f}{pct}{calls_s}{per_call}"
+            if not _THREAD_CPU:
+                cpu_s = ""
+            elif thread_cpu is None:
+                cpu_s = f"{'-':>10}"
+            else:
+                cpu_s = f"{thread_cpu:>10.3f}"
+            return f"  {label:<28}{seconds:>10.3f}{cpu_s}{pct}{calls_s}{per_call}"
 
         ordered = sorted(totals, key=sort_key)
         for phase in ordered:
@@ -174,37 +209,74 @@ class Profiler:
             # the one above it, so sibling times are not additive with the
             # parent's and the column must not be read as a total.
             label = ("  " * depth) + phase.split(".", 1)[-1] if depth else phase
-            lines.append(row(label, seconds, counts[phase]))
+            lines.append(row(label, seconds, cpu.get(phase), counts[phase]))
 
             # After listing a parent's children, show whatever of the parent is
             # not covered by them. Without this, a lightly-instrumented path
             # (--overlay, --sample) looks like it spends almost no time
             # anywhere, when really most of its work simply isn't broken down.
             if phase == "stage1.window_total":
-                children = sum(
-                    totals[p] for p in ordered if _PHASE_DEPTH.get(p, 0) == 2
-                )
-                remainder = seconds - children
+                kids = [p for p in ordered if _PHASE_DEPTH.get(p, 0) == 2]
+                remainder = seconds - sum(totals[p] for p in kids)
+                cpu_remainder = cpu.get(phase, 0.0) - sum(cpu.get(p, 0.0) for p in kids)
                 if remainder > 0.05 * seconds:
-                    lines.append(row("    (not broken down)", remainder, None))
+                    lines.append(
+                        row("    (not broken down)", remainder, cpu_remainder, None)
+                    )
 
         lines.append(f"  {'-' * (len(header) - 2)}")
         if wall:
-            lines.append(f"  {'wall clock':<28}{wall:>10.3f}{'  100.0%':>9}")
+            pad = 10 if _THREAD_CPU else 0
+            lines.append(f"  {'wall clock':<28}{wall:>10.3f}{'':>{pad}}{'  100.0%':>9}")
 
-        # Effective Stage 1 concurrency: work done across all worker threads
-        # divided by the wall time Stage 1 actually took. ~1.0 means the
-        # threads achieved nothing (GIL-bound or lock-serialised); ~N means
-        # N-way parallelism was realised.
-        stage1_wall = totals.get("stage1.wall")
-        stage1_work = totals.get("stage1.window_total")
-        if stage1_wall and stage1_work:
-            lines.append(
-                f"  Stage 1 concurrency: {stage1_work / stage1_wall:.2f}x "
-                f"({stage1_work:.3f}s of work in {stage1_wall:.3f}s wall)"
-            )
+        lines.extend(self._thread_lines(totals, cpu, context))
         lines.append("")
         return "\n".join(lines)
+
+    @staticmethod
+    def _thread_lines(
+        totals: dict[str, float], cpu: dict[str, float], context: dict[str, object]
+    ) -> list[str]:
+        """Report what Stage 1's worker threads actually achieved.
+
+        Parallelism is CPU seconds per second of elapsed Stage 1 time. It must
+        not be derived from summed worker *wall* time: a thread blocked on the
+        GDAL read lock or waiting for the GIL keeps accumulating wall time, so
+        that ratio tends towards the thread count precisely when the threads are
+        achieving nothing.
+        """
+        stage1_wall = totals.get("stage1.wall")
+        worker_wall = totals.get("stage1.window_total")
+        if not stage1_wall or not worker_wall:
+            return []
+
+        lines = []
+        if not _THREAD_CPU:  # pragma: no cover - platform dependent
+            lines.append(
+                f"  Stage 1 worker thread-time: {worker_wall:.3f}s in "
+                f"{stage1_wall:.3f}s wall (includes time blocked, so it is not "
+                f"a parallelism figure)"
+            )
+            return lines
+
+        worker_cpu = cpu.get("stage1.window_total", 0.0)
+        stalled = worker_wall - worker_cpu
+        lines.append(
+            f"  Stage 1 parallelism: {worker_cpu / stage1_wall:.2f}x "
+            f"({worker_cpu:.3f}s worker CPU in {stage1_wall:.3f}s wall)"
+        )
+        if worker_wall > 0:
+            lines.append(
+                f"  Stage 1 thread stall: {100 * stalled / worker_wall:.1f}% "
+                f"({stalled:.3f}s of {worker_wall:.3f}s thread-time blocked)"
+            )
+        threads = context.get("threads")
+        if isinstance(threads, int) and threads > 1 and worker_cpu / stage1_wall < 1.5:
+            lines.append(
+                f"  ^ {threads} threads are not paying for themselves here; "
+                f"compare against --threads 1"
+            )
+        return lines
 
 
 PROFILER = Profiler()

--- a/raster2dggs/profiling.py
+++ b/raster2dggs/profiling.py
@@ -15,12 +15,9 @@ Usage:
 Disabled (the default), ``phase()`` returns a shared no-op context manager, so
 the cost on the normal path is one attribute check.
 
-Each phase records elapsed wall time *and* the CPU time of the thread that ran
-it. Both are needed: a thread blocked on the GDAL read lock or waiting for the
-GIL keeps accumulating wall time, so summed worker wall time approaches the
-thread count whenever threads are contending -- which is exactly when
-parallelism is absent. CPU time excludes blocked time, so it is the figure that
-can tell work apart from waiting.
+Each phase records elapsed wall time and the CPU time of the thread that ran
+it. The gap between the two is time that thread spent blocked -- on the GDAL
+read lock, or waiting for the GIL.
 """
 
 from __future__ import annotations
@@ -34,9 +31,8 @@ from contextlib import contextmanager, nullcontext
 # nothing, so there is no per-use state to race on.
 _NULL_CONTEXT = nullcontext()
 
-# Per-thread CPU time. Documented as available on Linux and Windows, so treat
-# it as optional: without it the report simply omits the CPU column and the
-# figures derived from it.
+# Per-thread CPU time, available on Linux and Windows. Where it is absent the
+# report omits the CPU column and the two figures derived from it.
 try:
     time.thread_time()
 except (AttributeError, OSError):  # pragma: no cover - platform dependent
@@ -75,10 +71,9 @@ class Profiler:
     the ``report()`` snapshot are taken under a lock, which is what keeps the
     accumulator correct on free-threaded builds where the GIL does not.
 
-    Summed phase wall time exceeds the elapsed wall clock when worker threads
-    overlap -- but also when they merely block, so ``report()`` derives its
-    parallelism figure from CPU time and reports the gap between the two as
-    stall.
+    Summed phase wall time can exceed the elapsed wall clock, since worker
+    threads accumulate it both in parallel and while blocked. ``report()``
+    derives parallelism from CPU time and reports the wall/CPU gap as stall.
     """
 
     def __init__(self) -> None:
@@ -237,13 +232,11 @@ class Profiler:
     def _thread_lines(
         totals: dict[str, float], cpu: dict[str, float], context: dict[str, object]
     ) -> list[str]:
-        """Report what Stage 1's worker threads actually achieved.
+        """Summarise what Stage 1's worker threads achieved.
 
-        Parallelism is CPU seconds per second of elapsed Stage 1 time. It must
-        not be derived from summed worker *wall* time: a thread blocked on the
-        GDAL read lock or waiting for the GIL keeps accumulating wall time, so
-        that ratio tends towards the thread count precisely when the threads are
-        achieving nothing.
+        Parallelism is worker CPU seconds per second of elapsed Stage 1 time:
+        how many cores' worth of work the pool sustained. Stall is the share of
+        worker thread-time spent blocked rather than computing.
         """
         stage1_wall = totals.get("stage1.wall")
         worker_wall = totals.get("stage1.window_total")

--- a/tests/classes/test_profiling.py
+++ b/tests/classes/test_profiling.py
@@ -6,24 +6,42 @@ Stage 1's worker threads hit it concurrently, profiling disabled is a genuine
 no-op, and the CLI flag produces a report without altering output.
 """
 
+import re
 import threading
 import time
 
+import pytest
 from classes.base import TestRunthrough, read_output
 from classes.helpers import make_raster
 from click.testing import CliRunner
 from data.datapaths import TEST_OUTPUT_PATH
 
 from raster2dggs.cli import cli
-from raster2dggs.profiling import PROFILER, Profiler
+from raster2dggs.profiling import _THREAD_CPU, PROFILER, Profiler
 
 _BOUNDS = (174.0, -41.1, 174.1, -41.0)
 _SIZE = 10
 _RES = 8
 
+needs_thread_cpu = pytest.mark.skipif(
+    _THREAD_CPU is None, reason="platform has no per-thread CPU clock"
+)
+
 
 def _make_raster(path: str) -> None:
     make_raster(path, _BOUNDS, _SIZE, pixel_value=1.0)
+
+
+def _stat(report: str, label: str) -> float:
+    """Pull the number out of a 'Stage 1 <label>: <n>x/%' summary line."""
+    line = next(ln for ln in report.splitlines() if label in ln)
+    return float(re.search(r"([\d.]+)[x%]", line).group(1))
+
+
+def _burn_cpu(seconds: float) -> None:
+    end = time.perf_counter() + seconds
+    while time.perf_counter() < end:
+        pass
 
 
 class TestProfilerUnit:
@@ -145,6 +163,97 @@ class TestProfilerUnit:
         assert (len(inner) - len(inner.lstrip())) > (len(wall) - len(wall.lstrip()))
 
 
+class TestParallelismIsCPUBased:
+    """The parallelism figure must measure work, not elapsed time in a thread.
+
+    Deriving it from summed worker *wall* time makes it tend towards the thread
+    count whenever threads block, so it reads ~7x on runs that are slower than
+    --threads 1.
+
+    test_blocked_threads_are_not_reported_as_parallelism is the one that catches
+    that directly: substituting worker wall time back into the formula fails it
+    and nothing else. The rest guard the opposite error -- real work must not be
+    reported as stalled, and a single thread must not trigger the warning.
+    """
+
+    @staticmethod
+    def _threaded(work, n_threads: int) -> str:
+        p = Profiler()
+        p.reset(enabled=True)
+
+        def worker():
+            with p.phase("stage1.window_total"):
+                work()
+
+        with p.phase("stage1.wall"):
+            threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        p.stop()
+        return p.report()
+
+    @needs_thread_cpu
+    def test_sleeping_costs_wall_time_but_not_cpu_time(self):
+        p = Profiler()
+        p.reset(enabled=True)
+        with p.phase("stage1.window_total"):
+            time.sleep(0.05)
+        p.stop()
+
+        row = next(
+            ln
+            for ln in p.report().splitlines()
+            if ln.strip().startswith("window_total")
+        )
+        wall_s, cpu_s = row.split()[1], row.split()[2]
+        assert float(wall_s) >= 0.04
+        assert float(cpu_s) < 0.02
+
+    @needs_thread_cpu
+    def test_blocked_threads_are_not_reported_as_parallelism(self):
+        """Four threads that only sleep have achieved nothing, however much
+        thread-time they accumulate."""
+        report = self._threaded(lambda: time.sleep(0.1), n_threads=4)
+
+        assert _stat(report, "parallelism") < 0.5
+        assert _stat(report, "thread stall") > 90.0
+
+    @needs_thread_cpu
+    def test_a_single_busy_thread_reads_as_fully_occupied(self):
+        """The converse, and independent of how many cores are available: one
+        thread doing real work must not be reported as stalled."""
+        report = self._threaded(lambda: _burn_cpu(0.1), n_threads=1)
+
+        assert _stat(report, "parallelism") > 0.8
+        assert _stat(report, "thread stall") < 20.0
+
+    @needs_thread_cpu
+    def test_poor_parallelism_is_called_out_when_threads_were_requested(self):
+        p = Profiler()
+        p.reset(enabled=True)
+        p.note("threads", 7)
+        with p.phase("stage1.wall"):
+            with p.phase("stage1.window_total"):
+                time.sleep(0.05)
+        p.stop()
+
+        assert "not paying for themselves" in p.report()
+
+    @needs_thread_cpu
+    def test_no_warning_when_a_single_thread_was_requested(self):
+        p = Profiler()
+        p.reset(enabled=True)
+        p.note("threads", 1)
+        with p.phase("stage1.wall"):
+            with p.phase("stage1.window_total"):
+                time.sleep(0.05)
+        p.stop()
+
+        assert "not paying for themselves" not in p.report()
+
+
 class TestProfileCLI(TestRunthrough):
     def setUp(self):
         super().setUp()
@@ -177,6 +286,10 @@ class TestProfileCLI(TestRunthrough):
         # Context that makes the timings interpretable
         self.assertIn("windows", result.output)
         self.assertIn("bands", result.output)
+        if _THREAD_CPU is not None:
+            self.assertIn("cpu", result.output)
+            self.assertIn("Stage 1 parallelism", result.output)
+            self.assertIn("Stage 1 thread stall", result.output)
 
     def test_without_flag_no_report_and_profiler_disabled(self):
         result = self._invoke()


### PR DESCRIPTION
Follow-up to #90. The `Stage 1 concurrency` figure added there is wrong, and it
was hiding something worse than the number it got wrong.

## The defect

It was summed worker wall time divided by Stage 1's wall clock. A thread blocked
on the GDAL read lock, or waiting for the GIL, keeps accumulating wall time
exactly as a busy thread does — so the ratio tends towards the thread count
*precisely when the threads are achieving nothing*. It cannot distinguish seven
threads working from seven threads waiting, and it reads highest in the failure
case.

Measured against `--threads 1` on `TestDEM_tiled.tif`:

| path | 1 thread | 7 threads | real speedup | **old figure** |
|---|---|---|---|---|
| `--overlay weighted -r 8` | 22.50s | **31.96s** | **0.70x** | 6.98x |
| `--sample lanczos -r 8` | 5.43s | 6.47s | 0.84x | 6.90x |
| `--sample lanczos -r 11` | 21.06s | 20.47s | 1.03x | 6.96x |
| `--point value -r 11` | 27.31s | 25.45s | 1.07x | ~6.99x |

**Threading is a net loss on every path measured on this machine** (8 cores, 7
threads), and `--overlay` is 42% slower with it. #90 cited the old figures as
evidence that "`--overlay` already achieves 6.99x and `--sample` 6.91x, so
neither has a parallelism problem". That is the opposite of the truth, and the
metric is why it went unnoticed.

## The fix

Each phase now records `time.thread_time()` — per-thread CPU time, which
excludes blocked time — alongside `perf_counter()`. The report gains a `cpu`
column, and the summary becomes:

```
  Stage 1 parallelism: 1.22x (38.861s worker CPU in 31.748s wall)
  Stage 1 thread stall: 82.5% (182.986s of 221.847s thread-time blocked)
  ^ 7 threads are not paying for themselves here; compare against --threads 1
```

Parallelism is now worker CPU per second of Stage 1 wall clock — how many cores'
worth of work the pool actually achieved. The three cases above read 1.22x /
1.16x / 1.16x instead of ~7x, and the single-threaded control reads **0.99x with
0.7% stall**, which is the shape a correct metric should have.

Keeping both columns is deliberate: elapsed time is what a phase costs the run,
CPU time is what it costs in work, and the gap between them is the contention.
That gap is the new information — 82.5% of `--overlay`'s worker thread-time is
spent blocked, and 83.4% of `--point`'s.

`time.thread_time()` is documented for Linux and Windows only, so it is probed at
import; where unavailable, the column and both derived figures are omitted rather
than faked.

One wrinkle the README now states explicitly: the two dispatcher rows
(`stage1.wall`, `stage2.total`) are measured in the main thread while the work
happens in others, so their own `cpu` is near zero by construction.

## Verification

`tests/classes/test_profiling.py::TestParallelismIsCPUBased` — five tests:
sleeping accrues wall time but not CPU; four blocked threads report <0.5x
parallelism and >90% stall; one busy thread reports >0.8x and <20% stall
(core-count independent, so it holds on a single-core runner); the warning fires
when `--threads` > 1 and parallelism is poor, and stays quiet at `--threads 1`.

Mutation-checked rather than assumed: substituting worker wall time back into the
formula fails `test_blocked_threads_are_not_reported_as_parallelism` and nothing
else, so that test is the one carrying the regression. The other four guard the
opposite error — real work must not be reported as stalled. The test docstring
says which is which.

475 tests pass (5 new), `black` and `ruff` clean.

## Not addressed here

- **Whether `--threads` should default to `cpu_count - 1`.** On this evidence it
  should probably not, at least for `--overlay`. That is a behaviour change and
  wants its own measurement across machines, not a drive-by.
- **Why `--overlay` stalls 82% inside `exactextract`**, which is native C++ and
  might be expected to release the GIL. Unexplained.
- **`--sample`'s block reads.** `da.rio.isel_window(exp).values` costs 3.60
  ms/window against 0.30 ms for `src.read(window=exp)` — 12x, from dask graph
  construction per window. Not a one-line change: `src` is a single shared
  `DatasetReader` and GDAL datasets are not thread-safe, which is why the read
  goes through rioxarray behind a `SerializableLock`; bypassing it needs a
  thread-local dataset per worker.
- **Kernel stencil overlap**, which I raised as a candidate and then measured at
  1.6% / 3.1% / 4.7% extra pixels for bilinear / bicubic / lanczos on 256×256
  blocks. There is nothing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
