### PR TITLE
Read --sample windows through rasterio rather than dask (2.0x at coarse resolutions)

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -885,6 +885,7 @@ def initial_index(
                         resolution=resolution,
                         parent_res=parent_res,
                         selected_labels=selected_labels,
+                        selected_indices=tuple(selected_indices),
                         nodata_policy=nodata_policy,
                         emit_nodata_value=emit_nodata_value,
                         write_result=_write_result,

--- a/raster2dggs/transfers/interpolation.py
+++ b/raster2dggs/transfers/interpolation.py
@@ -15,6 +15,7 @@ common.py focused on orchestration.
 from __future__ import annotations
 
 import dataclasses
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -89,6 +90,7 @@ class _SampleIndexer:
     resolution: int
     parent_res: int
     selected_labels: tuple
+    selected_indices: tuple
     nodata_policy: str
     emit_nodata_value: Any | None
     write_result: Callable
@@ -98,6 +100,7 @@ class _SampleIndexer:
     lanczos_lobes: int = dataclasses.field(default=3)
 
     def __post_init__(self):
+        self._read_lock = threading.Lock()
         lobe = self.lanczos_lobes
         self._lanczos_ns: int = 2 * lobe
         self._lanczos_offsets_int: np.ndarray = np.arange(
@@ -147,6 +150,15 @@ class _SampleIndexer:
         frac_rows = inv.d * cell_xs + inv.e * cell_ys + inv.f - 0.5
 
         return cells, frac_rows, frac_cols
+
+    def _read_window(self, window) -> np.ndarray:
+        """Read the selected bands of a window as a (bands, H, W) array.
+
+        Reads are serialised: ``src`` is one GDAL dataset shared by every worker
+        thread, and GDAL datasets are not safe for concurrent access.
+        """
+        with PROFILER.phase("stage1.read_block"), self._read_lock:
+            return self.src.read(indexes=list(self.selected_indices), window=window)
 
     def _expand_window(self, window, margin: int):
         """Expand window by margin pixels, clamped to raster bounds."""
@@ -218,8 +230,7 @@ class _SampleIndexer:
         local_rows = local_rows[in_win]
         local_cols = local_cols[in_win]
 
-        with PROFILER.phase("stage1.read_block"):
-            win_data = self.da.rio.isel_window(window).values  # (bands, H, W)
+        win_data = self._read_window(window)
         samples = win_data[:, local_rows, local_cols].T.astype(float)
         if self.nodata is not None and not _is_nan(self.nodata):
             samples[samples == self.nodata] = np.nan
@@ -274,8 +285,7 @@ class _SampleIndexer:
         # available, even when the floor pixel is in the adjacent window
         # (cells with frac ∈ [nn−0.5, nn) have floor = nn−1).
         exp = self._expand_window(window, margin=1)
-        with PROFILER.phase("stage1.read_block"):
-            win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        win_data = self._read_window(exp)
         exp_h, exp_w = win_data.shape[1], win_data.shape[2]
 
         r0_raw = floor_rows - exp.row_off
@@ -397,8 +407,7 @@ class _SampleIndexer:
         dc = frac_cols - floor_cols
 
         exp = self._expand_window(window, margin=2)
-        with PROFILER.phase("stage1.read_block"):
-            win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        win_data = self._read_window(exp)
         exp_h, exp_w = win_data.shape[1], win_data.shape[2]
         n = len(cells)
         bands = win_data.shape[0]
@@ -488,8 +497,7 @@ class _SampleIndexer:
         offsets_float = self._lanczos_offsets_float
 
         exp = self._expand_window(window, margin=lobe)
-        with PROFILER.phase("stage1.read_block"):
-            win_data = self.da.rio.isel_window(exp).values  # (bands, H, W)
+        win_data = self._read_window(exp)
         exp_h, exp_w = win_data.shape[1], win_data.shape[2]
         n = len(cells)
         bands = win_data.shape[0]


### PR DESCRIPTION
Each `--sample` kernel read its window as `da.rio.isel_window(exp).values`,
building and computing a dask graph per window. The read needs no laziness — the
array is consumed immediately and whole — and the graph costs an order of
magnitude more than the read.

## What the cost actually was

I assumed the shared `SerializableLock` was serialising reads and throttling the
thread pool. It isn't. Measured over all 760 windows of the test DEM with the
lanczos margin, warm cache:

| read strategy | 1 thread | 7 threads | scaling |
|---|---|---|---|
| dask, shared lock *(current)* | 4.05 ms/window | 4.53 | 0.89x |
| dask, no lock | 5.21 | 4.97 | 1.05x |
| rasterio, shared lock | **0.48** | 0.50 | 0.96x |
| rasterio, dataset per thread | **0.50** | 0.44 | 1.14x |

Two things fall out:

- **Removing the lock changes nothing.** dask was the cost, not contention.
- **Reads do not scale with threads under any strategy** — 1.14x on 7 for the
  best case. They are bandwidth-bound on a cached file. So a dataset per thread
  buys nothing over one shared dataset behind a lock, and the shared dataset
  needs no per-thread file handles or lifecycle. That is what this uses.

## Effect

| `--sample lanczos`, full DEM | before | after | |
|---|---|---|---|
| `-r 8`, 1 thread | 5.43s | **2.71s** | **2.01x** |
| `-r 8`, 7 threads | 6.47s | **3.41s** | **1.90x** |
| `-r 11`, 1 thread | 21.06s | 18.38s | 1.15x |
| `-r 11`, 7 threads | 20.47s | 16.88s | 1.21x |
| `read_block` per window | 4.03 ms | 0.46 ms | 8.7x |

Largest at coarse resolutions, where few cells fall in each window so the
per-window read is most of the work. At `-r 11` there are ~2,874 cells per window
and the interpolation arithmetic dominates instead.

## Change

`_SampleIndexer` gains a `_read_window` helper and a `selected_indices` field,
matching the other two transfer contexts. The field is needed because the dask
`DataArray` had been pre-subset to the selected bands, whereas `src.read` takes
them explicitly — which makes band selection the riskiest part of this change, so
it is covered twice below.

## Verification

Output verified identical — schema and every value — against the previous
implementation across nine configurations: all four kernels (`nn`, `bilinear`,
`bicubic`, `lanczos`); a 10-band int16 raster with sentinel nodata; band
selection by **label** (`-b B08 -b B03 -b B12`) and by **index** (`-b 4 -b 2`);
the `emit` nodata policy on a NaN-nodata float raster; and rHEALPix.

470 tests pass, `black` and `ruff` clean.

Worth noting how nearly this went wrong: my first comparison reported differences
in every case. The fault was in the comparison, not the code — it sorted rows by
column 0, which is a *band value* with many duplicates, rather than by the cell
ID, which is the pandas index. Sorted correctly, all nine are identical. Row
counts and schemas matched from the outset, which is what suggested the harness
rather than the change.

## Still open

- **Threading remains a net loss at `-r 8`** (2.71s on 1 thread vs 3.41s on 7),
  unchanged in character by this PR. Reads do not scale, so read parallelism is
  not the lever; what is left is GIL-bound Python in the kernels. Separate
  problem, separate fix.
- **`--point` reads the same way** (`sdf.values` on a dask-backed window). Same
  ~9x is presumably available, but `index_func` takes an `xr.DataArray` as its
  contract, so it is a wider change for a smaller share of that path's runtime.
- **Kernel stencil overlap is not worth pursuing**: 1.6% / 3.1% / 4.7% extra
  pixels for bilinear / bicubic / lanczos on 256×256 blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
