### PR TITLE
Partition Stage 2 by parent cell rather than by size (fixes #94)

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -575,6 +575,57 @@ def _write_output(
         )
 
 
+def _stage1_partitioning(partition_col: str) -> ds.Partitioning:
+    """Hive partitioning for the Stage 1 store. The partition column is declared
+    a string because some cell IDs, geohash levels among them, otherwise read as
+    integers."""
+    return ds.partitioning(pa.schema([(partition_col, pa.string())]), flavor="hive")
+
+
+def _read_stage1_parent(pq_input: str, partition_col: str, parent: str) -> pd.DataFrame:
+    """Read every Stage 1 row belonging to one parent cell."""
+    dataset = ds.dataset(
+        pq_input, format="parquet", partitioning=_stage1_partitioning(partition_col)
+    )
+    return dataset.to_table(filter=ds.field(partition_col) == parent).to_pandas()
+
+
+def _read_stage1_by_parent(pq_input, partition_col: str) -> dd.DataFrame:
+    """Read the Stage 1 store as one partition per parent cell.
+
+    The aggregation that follows groups rows by cell, and a cell spanning two
+    raster windows has its pixels in several Stage 1 files, so every row for a
+    cell must reach the same partition. Parent directories are the coarsest
+    grouping that guarantees it, and hold a bounded number of cells (see
+    ``DGGS_Spec.default_parent_offset``).
+    """
+    dataset = ds.dataset(
+        str(pq_input),
+        format="parquet",
+        partitioning=_stage1_partitioning(partition_col),
+    )
+    parents = sorted(
+        set(
+            pa.compute.unique(
+                dataset.to_table(columns=[partition_col])[partition_col]
+            ).to_pylist()
+        )
+    )
+    LOGGER.debug("Stage 1 store spans %d parent cells", len(parents))
+    meta = _read_stage1_parent(str(pq_input), partition_col, parents[0]).head(0)
+    # --overlay list/histogram/fractions hold dicts and lists in their band
+    # columns, which dask's string conversion would stringify. Dtypes are fixed
+    # when the graph is built, so scoping it to construction is enough.
+    with dask.config.set({"dataframe.convert-string": False}):
+        return dd.from_map(
+            _read_stage1_parent,
+            [str(pq_input)] * len(parents),
+            [partition_col] * len(parents),
+            parents,
+            meta=meta,
+        )
+
+
 def address_boundary_issues(
     indexer: IRasterIndexer,
     pq_input: tempfile.TemporaryDirectory,
@@ -602,15 +653,7 @@ def address_boundary_issues(
     index_col = indexer.index_col(resolution)
     partition_col = indexer.partition_col(parent_res)
 
-    # Don't let partition schema be inferred; e.g. geohash levels can be
-    # inferred variously as int or string.
-    part_schema = pa.schema([(partition_col, pa.string())])
-    ddf = dd.read_parquet(
-        pq_input,
-        engine="pyarrow",
-        aggregate_files=True,
-        dataset={"partitioning": ds.partitioning(part_schema, flavor="hive")},
-    )
+    ddf = _read_stage1_by_parent(pq_input, partition_col)
     band_cols = [c for c in ddf.columns if not c.startswith(f"{indexer.dggs}_")]
     # Capture source dtypes before map_partitions changes them.
     # Stage 1 output for --overlay list/histogram already holds aggregated
@@ -653,6 +696,9 @@ def address_boundary_issues(
         else:
             mp_func = indexer.parent_groupby
             mp_args = (resolution, parent_res, aggfuncs, decimals)
+
+        # The partition count caps what Stage 2 can parallelise.
+        PROFILER.note("stage2_partitions", ddf.npartitions)
 
         ddf = ddf.map_partitions(mp_func, *mp_args, meta=out_meta)
 

--- a/tests/regression/test_stage2_partitioning.py
+++ b/tests/regression/test_stage2_partitioning.py
@@ -1,0 +1,125 @@
+"""
+Stage 2 must see every row for a cell at once.
+
+Stage 1 writes one file per raster window into a directory per parent cell, so a
+cell spanning two windows has its pixels in several files. Stage 2 groups by
+cell: a cell reaching two partitions is aggregated in each, giving duplicate
+rows whose values each cover only part of it.
+"""
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from raster2dggs import common
+from raster2dggs.indexerfactory import indexer_instance
+
+_RES, _PARENT_RES = 9, 3
+_PARENTS = 6
+_CELLS_PER_PARENT = 40
+_FILES_PER_PARENT = 8
+
+
+def _index_col():
+    return indexer_instance("h3").index_col(_RES)
+
+
+def _partition_col():
+    return indexer_instance("h3").partition_col(_PARENT_RES)
+
+
+@pytest.fixture
+def stage1_store(tmp_path):
+    """A store where every cell appears in all of its parent's files, as a cell
+    spanning many raster windows would. Returns (path, expected mean per cell)."""
+    index_col, partition_col = _index_col(), _partition_col()
+    store = tmp_path / "stage1"
+    values: dict[str, list[float]] = {}
+    for parent in range(_PARENTS):
+        cells = [f"8{parent:x}bb{i:010d}" for i in range(_CELLS_PER_PARENT)]
+        for file_no in range(_FILES_PER_PARENT):
+            # A distinct value per (cell, file), so a partial mean is detectable.
+            vals = np.array(
+                [100.0 * file_no + i for i in range(_CELLS_PER_PARENT)],
+                dtype=np.float64,
+            )
+            for cell, v in zip(cells, vals, strict=True):
+                values.setdefault(cell, []).append(float(v))
+            pq.write_to_dataset(
+                pa.table(
+                    {
+                        "band_1": vals,
+                        index_col: cells,
+                        partition_col: [f"8{parent:x}bbfffffffffff"]
+                        * _CELLS_PER_PARENT,
+                    }
+                ),
+                root_path=str(store),
+                partition_cols=[partition_col],
+                basename_template=f"{file_no}." + "{i}.parquet",
+                existing_data_behavior="overwrite_or_ignore",
+            )
+    return store, {c: float(np.mean(v)) for c, v in values.items()}
+
+
+def test_one_partition_per_parent(stage1_store):
+    """Partition count follows the parent directories, not a size target. A
+    size-driven reader puts all six parents in one partition, failing this and
+    the next test."""
+    store, _ = stage1_store
+    ddf = common._read_stage1_by_parent(store, _partition_col())
+
+    assert ddf.npartitions == _PARENTS
+
+
+def test_no_parent_is_split_across_partitions(stage1_store):
+    """The invariant itself: each partition holds exactly one whole parent."""
+    store, _ = stage1_store
+    partition_col = _partition_col()
+    ddf = common._read_stage1_by_parent(store, partition_col)
+
+    per_partition = ddf.map_partitions(
+        lambda df: pd.Series([tuple(sorted(set(df[partition_col])))]),
+        meta=pd.Series(dtype=object),
+    ).compute()
+
+    seen: set[str] = set()
+    for parents in per_partition:
+        assert len(parents) == 1, f"partition holds several parents: {parents}"
+        assert parents[0] not in seen, f"parent split across partitions: {parents[0]}"
+        seen.add(parents[0])
+    assert len(seen) == _PARENTS
+
+
+def test_each_cell_is_aggregated_once_over_all_its_files(stage1_store, tmp_path):
+    """One row per cell, averaging every file it appears in.
+
+    The property the partitioning protects, and the one that fails quietly. It
+    only catches a store large enough to have been split, so the two tests above
+    are what pin the mechanism.
+    """
+    store, expected = stage1_store
+    output = tmp_path / "out"
+    kwargs = common.assemble_kwargs(
+        compression="snappy",
+        processes=1,
+        aggfuncs=common.create_aggfuncs(("mean",)),
+        decimals=None,
+        overwrite=True,
+        compact=False,
+        geo="none",
+        point="value",
+    )
+    kwargs.update(common.resolve_to_internal("value", None, None))
+
+    common.address_boundary_issues(
+        indexer_instance("h3"), store, output, _RES, _PARENT_RES, **kwargs
+    )
+
+    got = pq.read_table(output).to_pandas()
+    assert len(got) == _PARENTS * _CELLS_PER_PARENT
+    assert not got.index.duplicated().any(), "a cell was aggregated more than once"
+    means = got["band_1"].to_dict()
+    assert means == pytest.approx(expected)


### PR DESCRIPTION
Fixes #94.

## The bug

Stage 2 groups rows by cell. It read the Stage 1 store with
`aggregate_files=True`, which lets dask group files into partitions **by total
size**, ignoring directory boundaries. A cell straddling two raster windows has
its pixels in several Stage 1 files — reconciling that is why Stage 2 exists — so
if two of those files land in different partitions, the cell is aggregated twice.

The result is duplicate rows whose values each cover only part of the cell, with
no error raised.

**It has not bitten because dask's size target is ~256 MB and the intermediate
store has been smaller**, so everything landed in one partition, and one
partition cannot split anything. Correctness rested on the size of the data
rather than on any rule keeping a parent's files together. Forcing the threshold
down turns 1800 expected rows into 4800.

`--profile` reported `stage2_partitions: 1` for every input tested — which is
exactly how this stayed invisible, and why that figure is now in the report.

## The fix

The store already records which files belong together: one directory per parent
cell. Reading one dask partition per parent makes the invariant structural rather
than incidental, independent of blocksize, dask version, or raster size. A parent
also holds a bounded number of cells — `DGGS_Spec.default_parent_offset` targets
~64K sub-zones — so the partitions are a sensible size.

**Setting `aggregate_files=<partition column>` is not sufficient**, which is worth
recording because it looks like the obvious one-line fix. It stops files from
*different* parents being merged, but still lets one parent be split across
partitions when it is large. Verified — it corrupts the same way.

## Verification

**Output identical to the previous implementation across 18 configurations, with
zero duplicate cells**: every output mode (`value`/`list`/`histogram`, all four
sample kernels, four overlay modes), `--compact` (which aggregates per partition
and is therefore the most sensitive), `--geo polygon`, `--decimals`, and one DGGS
per distinct indexer implementation. 483 tests pass, `black` and `ruff` clean.

Three new tests in `tests/regression/test_stage2_partitioning.py`. I checked which
actually fail against the old reader rather than assuming:

| test | vs old (default) | vs old (forced split) |
|---|---|---|
| `test_one_partition_per_parent` | **fails** | **fails** |
| `test_no_parent_is_split_across_partitions` | **fails** | **fails** |
| `test_each_cell_is_aggregated_once_over_all_its_files` | passes | **fails** |

The third is the end-to-end property, and the one that fails quietly — it can
only catch a store already large enough to have been split, so the first two are
what pin the mechanism. The docstrings say so, to stop them being deleted as
redundant.

## A trap worth flagging for review

My first attempt silently corrupted `--overlay fractions`. `dd.from_map` with an
object-dtype meta column triggers dask's string conversion, and **the dict values
came back as `str`** — struct data stringified, no error, surfacing only at the
final write as a schema mismatch. Only `--overlay fractions`, `--point list` and
`--point histogram` would have caught it.

Fixed by scoping `dataframe.convert-string: False` to graph construction; dtypes
are fixed at build time, which I verified is sufficient by computing outside the
scope.

## Incidental: Stage 2 is now parallel

The single partition also made Stage 2 serial. This is a side effect of
partitioning correctly, not the motivation:

| | stage2 | wall |
|---|---|---|
| dense 3-band uint16, r13 | 7.754s → **2.345s** | 16.6s → **11.3s** |
| DEM, `-a mean,max,min` | 3.823s → **1.744s** | |
| Sen2 10-band int16, r11 | 2.356s → **0.986s** | |

## Release framing

This is a latent correctness bug, not an active one: I have not confirmed a
real-world input that triggers it, and the trigger is the size of the
intermediate store rather than of the raster. Worth a judgement call on whether
it warrants a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
