### PR TITLE
Carry cell IDs as uint64 internally; add --cell-id [string|uint64] (closes #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Contributions (particularly for additional DGGSs), suggestions, bug reports and 
   - [Overlay (area-based)](#overlay-area-based---overlay)
   - [Numeric (binned) histograms](#numeric-binned-histograms---hist-bins---hist-width)
   - [Windowed resampling](#windowed-resampling---sample)
+- [Integer cell IDs](#integer-cell-ids---cell-id-uint64)
 - [Parallelism](#parallelism---processes)
 - [Profiling a run](#profiling-a-run----profile)
 - [Visualising output](#visualising-output)
@@ -244,6 +245,9 @@ Options:
                                   execution of this program. This parameter
                                   allows you to control where this data will
                                   be written.
+  --cell-id [string|uint64]       Cell ID output form: 'string' (default) or
+                                  'uint64' (unsigned 64-bit integers, e.g. for
+                                  DuckDB interop).  [default: string]
   --profile                       Print a phase-by-phase timing breakdown to
                                   stderr on completion, with per-call costs
                                   and enough context about the input (window
@@ -453,6 +457,16 @@ raster2dggs h3 landcover.tif output/ -r 9 --sample -d 0
 ```
 
 `--agg` is ignored for `--sample`. Supports `--compact`.
+
+## Integer cell IDs — `--cell-id uint64`
+
+DGGS with a native integer cell form (H3, S2, A5, and the DGGAL grids) can write cell and parent-cell columns as unsigned 64-bit integers instead of text:
+
+```bash
+raster2dggs h3 input.tif output/ -r 9 --cell-id uint64
+```
+
+Useful where downstream tools take integer cell IDs directly — e.g. DuckDB's `h3` extension accepts them without a conversion step. String-only DGGS (rHEALPix, Geohash, Maidenhead) reject `--cell-id uint64`.
 
 ## Parallelism — `--processes`
 

--- a/raster2dggs/cli_factory.py
+++ b/raster2dggs/cli_factory.py
@@ -124,10 +124,13 @@ class DGGS_Spec:
     default_parent_offset: int  # Chosen so as to be closest to containing 64K sub-zones
     help: str | None = None
     short_help: str | None = None
+    #: Whether the DGGS has a native integer cell form (--cell-id uint64).
+    #: Must agree with the indexer's CELL_ARROW_TYPE; a test asserts this.
+    int_cells: bool = False
 
 
 SPECS: list[DGGS_Spec] = [
-    DGGS_Spec("h3", "H3", const.MIN_H3, const.MAX_H3, 6),
+    DGGS_Spec("h3", "H3", const.MIN_H3, const.MAX_H3, 6, int_cells=True),
     DGGS_Spec("rhp", "rHEALPix", const.MIN_RHP, const.MAX_RHP, 5),
     DGGS_Spec("geohash", "Geohash", const.MIN_GEOHASH, const.MAX_GEOHASH, 4),
     DGGS_Spec(
@@ -137,25 +140,54 @@ SPECS: list[DGGS_Spec] = [
         const.MAX_MAIDENHEAD,
         3,
     ),
-    DGGS_Spec("s2", "S2", const.MIN_S2, const.MAX_S2, 8),
-    DGGS_Spec("a5", "A5", const.MIN_A5, const.MAX_A5, 8),
-    DGGS_Spec("isea4r", "ISEA4R", const.MIN_ISEA4R, const.MAX_ISEA4R, 8),
-    DGGS_Spec("isea9r", "ISEA9R", const.MIN_ISEA9R, const.MAX_ISEA9R, 5),
-    DGGS_Spec("isea3h", "ISEA3H", const.MIN_ISEA3H, const.MAX_ISEA3H, 10),
-    DGGS_Spec("isea7h", "ISEA7H", const.MIN_ISEA7H, const.MAX_ISEA7H, 6),
-    # DGGS_Spec("isea7h_z7", "ISEA7H_Z7", const.MIN_ISEA7H_Z7, const.MAX_ISEA7H_Z7, 6),
-    DGGS_Spec("ivea4r", "IVEA4R", const.MIN_IVEA4R, const.MAX_IVEA4R, 8),
-    DGGS_Spec("ivea9r", "IVEA9R", const.MIN_IVEA9R, const.MAX_IVEA9R, 5),
-    DGGS_Spec("ivea3h", "IVEA3H", const.MIN_IVEA3H, const.MAX_IVEA3H, 10),
-    DGGS_Spec("ivea7h", "IVEA7H", const.MIN_IVEA7H, const.MAX_IVEA7H, 6),
-    # DGGS_Spec("ivea7h_z7", "IVEA7H_Z7", const.MIN_IVEA7H_Z7, const.MAX_IVEA7H_Z7, 6),
-    DGGS_Spec("rtea4r", "RTEA4R", const.MIN_RTEA4R, const.MAX_RTEA4R, 8),
-    DGGS_Spec("rtea9r", "RTEA9R", const.MIN_RTEA9R, const.MAX_RTEA9R, 5),
-    DGGS_Spec("rtea7h", "RTEA7H", const.MIN_RTEA7H, const.MAX_RTEA7H, 6),
-    # DGGS_Spec("rtea7h_z7", "RTEA7H_Z7", const.MIN_RTEA7H_Z7, const.MAX_RTEA7H_Z7, 6),
-    DGGS_Spec("healpix", "HEALPix", const.MIN_HEALPIX, const.MAX_HEALPIX, 5),
+    DGGS_Spec("s2", "S2", const.MIN_S2, const.MAX_S2, 8, int_cells=True),
+    DGGS_Spec("a5", "A5", const.MIN_A5, const.MAX_A5, 8, int_cells=True),
     DGGS_Spec(
-        "rhealpix", "rHEALPix", const.MIN_RHEALPIX, const.MAX_RHEALPIX, 5
+        "isea4r", "ISEA4R", const.MIN_ISEA4R, const.MAX_ISEA4R, 8, int_cells=True
+    ),
+    DGGS_Spec(
+        "isea9r", "ISEA9R", const.MIN_ISEA9R, const.MAX_ISEA9R, 5, int_cells=True
+    ),
+    DGGS_Spec(
+        "isea3h", "ISEA3H", const.MIN_ISEA3H, const.MAX_ISEA3H, 10, int_cells=True
+    ),
+    DGGS_Spec(
+        "isea7h", "ISEA7H", const.MIN_ISEA7H, const.MAX_ISEA7H, 6, int_cells=True
+    ),
+    # DGGS_Spec("isea7h_z7", "ISEA7H_Z7", const.MIN_ISEA7H_Z7, const.MAX_ISEA7H_Z7, 6),
+    DGGS_Spec(
+        "ivea4r", "IVEA4R", const.MIN_IVEA4R, const.MAX_IVEA4R, 8, int_cells=True
+    ),
+    DGGS_Spec(
+        "ivea9r", "IVEA9R", const.MIN_IVEA9R, const.MAX_IVEA9R, 5, int_cells=True
+    ),
+    DGGS_Spec(
+        "ivea3h", "IVEA3H", const.MIN_IVEA3H, const.MAX_IVEA3H, 10, int_cells=True
+    ),
+    DGGS_Spec(
+        "ivea7h", "IVEA7H", const.MIN_IVEA7H, const.MAX_IVEA7H, 6, int_cells=True
+    ),
+    # DGGS_Spec("ivea7h_z7", "IVEA7H_Z7", const.MIN_IVEA7H_Z7, const.MAX_IVEA7H_Z7, 6),
+    DGGS_Spec(
+        "rtea4r", "RTEA4R", const.MIN_RTEA4R, const.MAX_RTEA4R, 8, int_cells=True
+    ),
+    DGGS_Spec(
+        "rtea9r", "RTEA9R", const.MIN_RTEA9R, const.MAX_RTEA9R, 5, int_cells=True
+    ),
+    DGGS_Spec(
+        "rtea7h", "RTEA7H", const.MIN_RTEA7H, const.MAX_RTEA7H, 6, int_cells=True
+    ),
+    # DGGS_Spec("rtea7h_z7", "RTEA7H_Z7", const.MIN_RTEA7H_Z7, const.MAX_RTEA7H_Z7, 6),
+    DGGS_Spec(
+        "healpix", "HEALPix", const.MIN_HEALPIX, const.MAX_HEALPIX, 5, int_cells=True
+    ),
+    DGGS_Spec(
+        "rhealpix",
+        "rHEALPix",
+        const.MIN_RHEALPIX,
+        const.MAX_RHEALPIX,
+        5,
+        int_cells=True,
     ),  # Prefer rhp
 ]
 # NB use 5 for IS/VEA9R, and 10 for IS/VEA3H, and 8 for GNOSIS --- corresponds to ~64K sub-zones
@@ -194,6 +226,7 @@ def run_index(
     hist_origin: float = 0.0,
     hist_weight: str = "count",
     hist_normalize: str = "none",
+    cell_id: str = "string",
     profile: bool = False,
 ):
     tempfile.tempdir = tempdir if tempdir is not None else tempfile.tempdir
@@ -219,6 +252,7 @@ def run_index(
         hist_origin,
         hist_weight,
         hist_normalize,
+        cell_id,
     )
 
     PROFILER.reset(enabled=profile)
@@ -498,6 +532,20 @@ def make_command(spec: DGGS_Spec):
         help="Temporary data is created during the execution of this program. This parameter allows you to control where this data will be written.",
     )
     @click.option(
+        "--cell-id",
+        type=click.Choice(
+            [str(c) for c in const.CellId]
+            if spec.int_cells
+            else [str(const.CellId.STRING)]
+        ),
+        default=str(const.CellId.STRING),
+        help=(
+            "Cell ID output form: 'string' (default) or 'uint64' (unsigned 64-bit integers, e.g. for DuckDB interop)."
+            if spec.int_cells
+            else f"Cell ID output form. {spec.pretty} cell IDs are strings with no integer form, so only 'string' is available."
+        ),
+    )
+    @click.option(
         "--profile",
         is_flag=True,
         help=(
@@ -532,6 +580,7 @@ def make_command(spec: DGGS_Spec):
         hist_origin,
         hist_weight,
         hist_normalize,
+        cell_id,
         profile,
     ):
         if isinstance(resolution, str):
@@ -614,6 +663,7 @@ def make_command(spec: DGGS_Spec):
             hist_origin,
             hist_weight,
             hist_normalize,
+            cell_id,
             profile,
         )
 

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -308,6 +308,7 @@ def assemble_kwargs(
     hist_origin: float = 0.0,
     hist_weight: str = "count",
     hist_normalize: str = "none",
+    cell_id: str = "string",
 ) -> dict:
     return {
         "compression": compression,
@@ -326,6 +327,7 @@ def assemble_kwargs(
         "hist_origin": hist_origin,
         "hist_weight": hist_weight,
         "hist_normalize": hist_normalize,
+        "cell_id": cell_id,
     }
 
 
@@ -336,9 +338,19 @@ def write_partition_as_geoparquet(
     partition_col_name: str,
     compression: str,
     schema: pa.Schema,
+    cells_to_string=None,
 ) -> None:
-    # Build shapely geometries for this partition
+    # Build shapely geometries for this partition. geom_func takes the working
+    # cell form, so geometry comes first and any string conversion after.
     geoms = pdf.index.map(geom_func)
+    if cells_to_string is not None:
+        pdf = pdf.copy(deep=False)
+        pdf.index = pd.Index(
+            cells_to_string(pdf.index), name=pdf.index.name, dtype="string"
+        )
+        pdf[partition_col_name] = pd.Series(
+            cells_to_string(pdf[partition_col_name]), index=pdf.index, dtype="string"
+        )
 
     # Compute GeoParquet 1.1.0 extras
     valid = [g for g in geoms if (g is not None and not g.is_empty)]
@@ -414,6 +426,7 @@ def _build_output_meta(
     index_col: str,
     compact: bool,
     interp: str,
+    cell_dtype: str = "string",
 ) -> tuple[pd.DataFrame, str]:
     if (
         transfer == const.Transfer.SAMPLE
@@ -430,7 +443,7 @@ def _build_output_meta(
     ):
         out_meta = pd.DataFrame(
             {
-                partition_col: pd.Series([], dtype="string"),
+                partition_col: pd.Series([], dtype=cell_dtype),
                 **{
                     c: pd.Series(
                         [],
@@ -458,7 +471,7 @@ def _build_output_meta(
         # list, histogram, or multi-agg value — object-typed columns
         out_meta = pd.DataFrame(
             {
-                partition_col: pd.Series([], dtype="string"),
+                partition_col: pd.Series([], dtype=cell_dtype),
                 **{c: pd.Series([], dtype="object") for c in band_cols},
             }
         )
@@ -467,7 +480,7 @@ def _build_output_meta(
             if out != const.OutputSchema.VALUE
             else f"Aggregating{'/compacting' if compact else ''}"
         )
-    out_meta.index = pd.Index([], name=index_col, dtype="string")
+    out_meta.index = pd.Index([], name=index_col, dtype=cell_dtype)
     return out_meta, tqdm_label
 
 
@@ -482,10 +495,12 @@ def _build_write_schema(
     partition_col: str,
     out_meta: pd.DataFrame,
     hist_spec: histogram.HistogramSpec | None = None,
+    cell_type: pa.DataType | None = None,
 ) -> pa.Schema:
+    cell_type = cell_type if cell_type is not None else pa.string()
     common_fields = [
-        pa.field(index_col, pa.string()),
-        pa.field(partition_col, pa.string()),
+        pa.field(index_col, cell_type),
+        pa.field(partition_col, cell_type),
     ]
     if out == const.OutputSchema.FRACTIONS:
         frac_struct = pa.struct(
@@ -530,7 +545,15 @@ def _build_write_schema(
                 for c in band_cols
             ]
         )
-    return pa.Schema.from_pandas(out_meta, preserve_index=True)
+    # The meta carries the working cell form; the written form follows
+    # cell_type. Coercing a copy of the meta and letting from_pandas derive the
+    # fields keeps the schema identical to one built from text cells directly.
+    schema_meta = out_meta
+    if cell_type == pa.string() and str(out_meta.index.dtype) != "string":
+        schema_meta = out_meta.copy()
+        schema_meta.index = out_meta.index.astype("string")
+        schema_meta[partition_col] = schema_meta[partition_col].astype("string")
+    return pa.Schema.from_pandas(schema_meta, preserve_index=True)
 
 
 def _write_output(
@@ -543,6 +566,7 @@ def _write_output(
     overwrite: bool,
     write_schema: pa.Schema,
     indexer: IRasterIndexer,
+    cells_to_string=None,
 ) -> None:
     if geo:
         delayed_parts = ddf.to_delayed()
@@ -557,6 +581,7 @@ def _write_output(
                 partition_col,
                 compression,
                 write_schema,
+                cells_to_string,
             )
             for part in delayed_parts
         ]
@@ -575,22 +600,32 @@ def _write_output(
         )
 
 
-def _stage1_partitioning(partition_col: str) -> ds.Partitioning:
-    """Hive partitioning for the Stage 1 store. The partition column is declared
-    a string because some cell IDs, geohash levels among them, otherwise read as
-    integers."""
-    return ds.partitioning(pa.schema([(partition_col, pa.string())]), flavor="hive")
+def _stage1_partitioning(partition_col: str, cell_type: pa.DataType) -> ds.Partitioning:
+    """Hive partitioning for the Stage 1 store. The partition column type is
+    declared rather than inferred: string cell IDs otherwise read as integers
+    for some backends (geohash levels among them)."""
+    return ds.partitioning(pa.schema([(partition_col, cell_type)]), flavor="hive")
 
 
-def _read_stage1_parent(pq_input: str, partition_col: str, parent: str) -> pd.DataFrame:
+def _read_stage1_parent(
+    pq_input: str, partition_col: str, cell_type: pa.DataType, parent
+) -> pd.DataFrame:
     """Read every Stage 1 row belonging to one parent cell."""
     dataset = ds.dataset(
-        pq_input, format="parquet", partitioning=_stage1_partitioning(partition_col)
+        pq_input,
+        format="parquet",
+        partitioning=_stage1_partitioning(partition_col, cell_type),
     )
-    return dataset.to_table(filter=ds.field(partition_col) == parent).to_pandas()
+    # A typed scalar: a bare Python int past 2^63 (S2 faces 4-5) overflows the
+    # default int64 conversion.
+    return dataset.to_table(
+        filter=ds.field(partition_col) == pa.scalar(parent, type=cell_type)
+    ).to_pandas()
 
 
-def _read_stage1_by_parent(pq_input, partition_col: str) -> dd.DataFrame:
+def _read_stage1_by_parent(
+    pq_input, partition_col: str, cell_type: pa.DataType
+) -> dd.DataFrame:
     """Read the Stage 1 store as one partition per parent cell.
 
     The aggregation that follows groups rows by cell, and a cell spanning two
@@ -602,7 +637,7 @@ def _read_stage1_by_parent(pq_input, partition_col: str) -> dd.DataFrame:
     dataset = ds.dataset(
         str(pq_input),
         format="parquet",
-        partitioning=_stage1_partitioning(partition_col),
+        partitioning=_stage1_partitioning(partition_col, cell_type),
     )
     parents = sorted(
         set(
@@ -612,7 +647,9 @@ def _read_stage1_by_parent(pq_input, partition_col: str) -> dd.DataFrame:
         )
     )
     LOGGER.debug("Stage 1 store spans %d parent cells", len(parents))
-    meta = _read_stage1_parent(str(pq_input), partition_col, parents[0]).head(0)
+    meta = _read_stage1_parent(
+        str(pq_input), partition_col, cell_type, parents[0]
+    ).head(0)
     # --overlay list/histogram/fractions hold dicts and lists in their band
     # columns, which dask's string conversion would stringify. Dtypes are fixed
     # when the graph is built, so scoping it to construction is enough.
@@ -621,9 +658,24 @@ def _read_stage1_by_parent(pq_input, partition_col: str) -> dd.DataFrame:
             _read_stage1_parent,
             [str(pq_input)] * len(parents),
             [partition_col] * len(parents),
+            [cell_type] * len(parents),
             parents,
             meta=meta,
         )
+
+
+def _cells_frame_to_string(
+    pdf: pd.DataFrame, indexer: IRasterIndexer, partition_col: str
+) -> pd.DataFrame:
+    """Convert a partition's working-form cell index and parent column to strings."""
+    pdf = pdf.copy(deep=False)
+    pdf.index = pd.Index(
+        indexer.cells_to_string(pdf.index), name=pdf.index.name, dtype="string"
+    )
+    pdf[partition_col] = pd.Series(
+        indexer.cells_to_string(pdf[partition_col]), index=pdf.index, dtype="string"
+    )
+    return pdf
 
 
 def address_boundary_issues(
@@ -653,7 +705,7 @@ def address_boundary_issues(
     index_col = indexer.index_col(resolution)
     partition_col = indexer.partition_col(parent_res)
 
-    ddf = _read_stage1_by_parent(pq_input, partition_col)
+    ddf = _read_stage1_by_parent(pq_input, partition_col, indexer.CELL_ARROW_TYPE)
     band_cols = [c for c in ddf.columns if not c.startswith(f"{indexer.dggs}_")]
     # Capture source dtypes before map_partitions changes them.
     # Stage 1 output for --overlay list/histogram already holds aggregated
@@ -669,6 +721,17 @@ def address_boundary_issues(
     transfer = kwargs.get("transfer", const.Transfer.ASSIGN_CENTERS)
     decimals = kwargs.get("decimals")
     aggfuncs = kwargs.get("aggfuncs", [("mean", "mean")])
+    # String output needs a conversion for backends that carry integers
+    # internally; for string backends it is already the working form.
+    emit_string = (
+        kwargs.get("cell_id", const.CellId.STRING) == const.CellId.STRING
+        and indexer.CELL_ARROW_TYPE != pa.string()
+    )
+    output_cell_type = (
+        pa.string()
+        if kwargs.get("cell_id", const.CellId.STRING) == const.CellId.STRING
+        else indexer.CELL_ARROW_TYPE
+    )
 
     out_meta, tqdm_label = _build_output_meta(
         transfer=transfer,
@@ -681,6 +744,7 @@ def address_boundary_issues(
         index_col=index_col,
         compact=kwargs["compact"],
         interp=kwargs.get("interp", const.Interp.NN),
+        cell_dtype=indexer.cell_pd_dtype,
     )
 
     with PROFILER.phase("stage2.total"), TqdmCallback(desc=tqdm_label):
@@ -707,6 +771,16 @@ def address_boundary_issues(
                 indexer.compaction, resolution, parent_res, meta=out_meta
             )
 
+        if emit_string and not kwargs["geo"]:
+            # The GeoParquet path converts inside its writer instead, after
+            # geometries have been built from the working form.
+            string_meta = out_meta.copy()
+            string_meta.index = out_meta.index.astype("string")
+            string_meta[partition_col] = string_meta[partition_col].astype("string")
+            ddf = ddf.map_partitions(
+                _cells_frame_to_string, indexer, partition_col, meta=string_meta
+            )
+
         hist_spec = kwargs.get("hist_spec")
         write_schema = _build_write_schema(
             out=out,
@@ -718,6 +792,7 @@ def address_boundary_issues(
             partition_col=partition_col,
             out_meta=out_meta,
             hist_spec=hist_spec,
+            cell_type=output_cell_type,
         )
         if out == const.OutputSchema.HISTOGRAM and hist_spec is not None:
             hist_meta = {
@@ -745,6 +820,7 @@ def address_boundary_issues(
             overwrite=kwargs["overwrite"],
             write_schema=write_schema,
             indexer=indexer,
+            cells_to_string=indexer.cells_to_string if emit_string else None,
         )
 
     LOGGER.debug("Stage 2 (aggregation) complete")
@@ -991,6 +1067,16 @@ def initial_index(
         raise click.UsageError(
             f"--transfer {kwargs['transfer']!r} requires spatial cell enumeration, "
             f"which is not supported by the {dggs!r} DGGS."
+        )
+
+    if (
+        kwargs.get("cell_id", const.CellId.STRING) == const.CellId.UINT64
+        and indexer.CELL_ARROW_TYPE == pa.string()
+    ):
+        raise click.UsageError(
+            f"--cell-id uint64: the {dggs!r} DGGS has no integer cell form "
+            f"(its cell IDs are strings such as geohashes or rHEALPix addresses), "
+            f"or integer support has not been implemented for it yet."
         )
 
     LOGGER.info(

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -170,6 +170,11 @@ class OutputSchema(StrEnum):
     LIST = "list"
 
 
+class CellId(StrEnum):
+    STRING = "string"
+    UINT64 = "uint64"
+
+
 class HistWeight(StrEnum):
     COUNT = "count"
     AREA = "area"

--- a/raster2dggs/indexers/a5rasterindexer.py
+++ b/raster2dggs/indexers/a5rasterindexer.py
@@ -8,6 +8,7 @@ import threading
 import a5 as a5py
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import shapely
 
 import raster2dggs.constants as const
@@ -34,7 +35,16 @@ def _locked(fn):
 class A5RasterIndexer(RasterIndexer):
     """
     Provides integration for the A5 DGGS.
+
+    pya5 cells are natively uint64; the hexadecimal form is produced only at
+    the output boundary via cells_to_string.
     """
+
+    CELL_ARROW_TYPE: pa.DataType = pa.uint64()
+
+    @_locked
+    def cells_to_string(self, cells) -> list:
+        return [a5py.u64_to_hex(int(c)) for c in cells]
 
     @_locked
     def _index_window(self, wide, resolution: int, parent_res: int):
@@ -44,13 +54,13 @@ class A5RasterIndexer(RasterIndexer):
             a5py.lonlat_to_cell((lon, lat), resolution)
             for lon, lat in zip(wide["x"], wide["y"], strict=True)
         ]
-        a5_parent = [a5py.cell_to_parent(cell, parent_res) for cell in cells]
+        n = len(cells)
         wide = wide.drop(columns=["x", "y"])
-        wide[self.index_col(resolution)] = pd.Series(
-            map(a5py.u64_to_hex, cells), index=wide.index
-        )
-        wide[self.partition_col(parent_res)] = pd.Series(
-            map(a5py.u64_to_hex, a5_parent), index=wide.index
+        wide[self.index_col(resolution)] = np.fromiter(cells, dtype=np.uint64, count=n)
+        wide[self.partition_col(parent_res)] = np.fromiter(
+            (a5py.cell_to_parent(cell, parent_res) for cell in cells),
+            dtype=np.uint64,
+            count=n,
         )
         return wide
 
@@ -62,7 +72,7 @@ class A5RasterIndexer(RasterIndexer):
 
         Implementation of interface function.
         """
-        cell_level = a5py.get_resolution(cell)
+        cell_level = a5py.get_resolution(int(cell))
         return a5py.get_num_children(cell_level, desired_resolution)
 
     @_locked
@@ -88,37 +98,25 @@ class A5RasterIndexer(RasterIndexer):
         """
         # Materialised eagerly (not a lazy map) so the a5py calls happen while
         # the lock is held, rather than later when the caller consumes it.
-        return list(
-            map(
-                a5py.u64_to_hex,
-                map(
-                    lambda x: a5py.cell_to_parent(x, resolution),
-                    map(a5py.hex_to_u64, cells),
-                ),
-            )
-        )
+        return [a5py.cell_to_parent(int(c), resolution) for c in cells]
 
     @_locked
-    def expected_count(self, parent: str, resolution: int):
+    def expected_count(self, parent, resolution: int):
         """
         Implementation of interface function.
         """
-        return self.cell_to_children_size(a5py.hex_to_u64(parent), resolution)
+        return self.cell_to_children_size(int(parent), resolution)
 
     @staticmethod
     @_locked
-    def is_valid_a5_cell(cell: str) -> bool:
+    def is_valid_a5_cell(cell) -> bool:
         """
         Returns cell validity.
 
         Not a part of the RasterIndexer interface
         """
         try:
-            return (
-                const.MIN_A5
-                <= a5py.get_resolution(a5py.hex_to_u64(cell))
-                <= const.MAX_A5
-            )
+            return const.MIN_A5 <= a5py.get_resolution(int(cell)) <= const.MAX_A5
         except Exception:
             return False
 
@@ -150,7 +148,7 @@ class A5RasterIndexer(RasterIndexer):
         ]
         compacted = a5py.polygon_to_cells(ring, resolution)
         cells = a5py.uncompact(compacted, resolution)
-        return {a5py.u64_to_hex(c) for c in cells}
+        return {int(c) for c in cells}
 
     @_locked
     def cell_area_m2(self, resolution: int, lat: float, lon: float) -> float:
@@ -164,7 +162,7 @@ class A5RasterIndexer(RasterIndexer):
     @_locked
     def cells_to_lonlat_arrays(cells: pd.Series) -> tuple[np.ndarray, np.ndarray]:
         # a5py.cell_to_lonlat returns (lon, lat) directly
-        pts = np.array([a5py.cell_to_lonlat(a5py.hex_to_u64(c)) for c in cells])
+        pts = np.array([a5py.cell_to_lonlat(int(c)) for c in cells])
         # a5py may return longitudes outside [-180, 180]; normalise to standard range.
         lons = (pts[:, 0] + 180.0) % 360.0 - 180.0
         lats = pts[:, 1]
@@ -172,14 +170,12 @@ class A5RasterIndexer(RasterIndexer):
 
     @staticmethod
     @_locked
-    def cell_to_point(cell: str) -> shapely.geometry.Point:
-        cell_u64 = a5py.hex_to_u64(cell)
-        lon, lat = a5py.cell_to_lonlat(cell_u64)
+    def cell_to_point(cell) -> shapely.geometry.Point:
+        lon, lat = a5py.cell_to_lonlat(int(cell))
         lon = (lon + 180.0) % 360.0 - 180.0  # normalise to [-180, 180]
         return shapely.Point(lon, lat)
 
     @staticmethod
     @_locked
-    def cell_to_polygon(cell: str) -> shapely.geometry.Polygon:
-        cell = a5py.hex_to_u64(cell)
-        return shapely.Polygon(tuple(a5py.cell_to_boundary(cell)))
+    def cell_to_polygon(cell) -> shapely.geometry.Polygon:
+        return shapely.Polygon(tuple(a5py.cell_to_boundary(int(cell))))

--- a/raster2dggs/indexers/dggalrasterindexer.py
+++ b/raster2dggs/indexers/dggalrasterindexer.py
@@ -4,6 +4,7 @@ from functools import cache, lru_cache
 import dggal
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pyproj
 import shapely
 
@@ -19,7 +20,16 @@ DGGAL_NULL_ZONE: int = 2**64 - 1
 class DGGALRasterIndexer(RasterIndexer):
     """
     Provides integration for DGGRSs depending on the DGGAL API.
+
+    Zones are handled as uint64 throughout; the structured text ID (e.g.
+    ``K7-FAD45``) is produced only at the output boundary via cells_to_string,
+    which needs the dggrs instance.
     """
+
+    CELL_ARROW_TYPE: pa.DataType = pa.uint64()
+
+    def cells_to_string(self, cells) -> list:
+        return [self.dggrs.getZoneTextID(int(c)) for c in cells]
 
     @property
     @abstractmethod
@@ -57,25 +67,25 @@ class DGGALRasterIndexer(RasterIndexer):
             self.dggrs.getZoneFromWGS84Centroid(resolution, dggal.GeoPoint(lon, lat))
             for lon, lat in zip(wide["y"], wide["x"], strict=True)
         ]  # Vectorised
-        dggrs_parent = [
-            self._get_ancestor(zone, resolution - parent_res) for zone in cells
-        ]
+        n = len(cells)
         wide = wide.drop(columns=["x", "y"])
-        wide[self.index_col(resolution)] = pd.Series(
-            map(self.dggrs.getZoneTextID, cells), index=wide.index
+        wide[self.index_col(resolution)] = np.fromiter(
+            (int(z) for z in cells), dtype=np.uint64, count=n
         )
-        wide[self.partition_col(parent_res)] = pd.Series(
-            map(self.dggrs.getZoneTextID, dggrs_parent), index=wide.index
+        wide[self.partition_col(parent_res)] = np.fromiter(
+            (int(self._get_ancestor(zone, resolution - parent_res)) for zone in cells),
+            dtype=np.uint64,
+            count=n,
         )
         return wide
 
-    def cell_to_children_size(self, cell: str, desired_resolution: int) -> int:
+    def cell_to_children_size(self, cell, desired_resolution: int) -> int:
         """
         Determine total number of children at some offset resolution
 
         Implementation of interface function.
         """
-        zone = self.dggrs.getZoneFromTextID(cell)
+        zone = int(cell)
         current_resolution = self.dggrs.getZoneLevel(zone)
         depth = desired_resolution - current_resolution
 
@@ -95,24 +105,19 @@ class DGGALRasterIndexer(RasterIndexer):
         """
         Implementation of interface function.
         """
-        child_resolution = self.dggrs.getZoneLevel(
-            self.dggrs.getZoneFromTextID(next(iter(cells)))
-        )
+        child_resolution = self.dggrs.getZoneLevel(int(next(iter(cells))))
         relative_depth = child_resolution - resolution
 
         if self.dggs in ("isea3h", "ivea3h", "rtea3h"):
             all_parents = []
-            for zone_text in cells:
-                zone = self.dggrs.getZoneFromTextID(zone_text)
+            for cell in cells:
                 # Get ancestors via all parent paths
-                ancestors = self._get_all_ancestors_3h(zone, relative_depth)
-                all_parents.extend(self.dggrs.getZoneTextID(a) for a in ancestors)
+                ancestors = self._get_all_ancestors_3h(int(cell), relative_depth)
+                all_parents.extend(int(a) for a in ancestors)
             return all_parents
 
         return map(
-            lambda zone: self.dggrs.getZoneTextID(
-                self._get_ancestor(self.dggrs.getZoneFromTextID(zone), relative_depth)
-            ),
+            lambda cell: int(self._get_ancestor(int(cell), relative_depth)),
             cells,
         )
 
@@ -125,14 +130,10 @@ class DGGALRasterIndexer(RasterIndexer):
         one representative parent — the centroid-parent path, which is what
         _get_ancestor already uses for all DGGAL grids.
         """
-        child_resolution = self.dggrs.getZoneLevel(
-            self.dggrs.getZoneFromTextID(next(iter(cells)))
-        )
+        child_resolution = self.dggrs.getZoneLevel(int(next(iter(cells))))
         relative_depth = child_resolution - resolution
         return map(
-            lambda zone: self.dggrs.getZoneTextID(
-                self._get_ancestor(self.dggrs.getZoneFromTextID(zone), relative_depth)
-            ),
+            lambda cell: int(self._get_ancestor(int(cell), relative_depth)),
             cells,
         )
 
@@ -194,7 +195,7 @@ class DGGALRasterIndexer(RasterIndexer):
             lat = float(centroid.lat)
             lon = float(centroid.lon)
             if min_lat <= lat <= max_lat and min_lon <= lon <= max_lon:
-                result.add(self.dggrs.getZoneTextID(zone))
+                result.add(int(zone))
         return result
 
     def cell_area_m2(self, resolution: int, lat: float, lon: float) -> float:
@@ -210,26 +211,21 @@ class DGGALRasterIndexer(RasterIndexer):
         pts = np.array(
             [
                 (gp.lon, gp.lat)
-                for gp in (
-                    self.dggrs.getZoneWGS84Centroid(self.dggrs.getZoneFromTextID(c))
-                    for c in cells
-                )
+                for gp in (self.dggrs.getZoneWGS84Centroid(int(c)) for c in cells)
             ],
             dtype=float,  # ecrt.Degrees objects need an explicit cast
         )
         return pts[:, 0], pts[:, 1]  # lons, lats
 
-    def cell_to_point(self, cell: str) -> shapely.geometry.Point:
-        geo_point: dggal.GeoPoint = self.dggrs.getZoneWGS84Centroid(
-            self.dggrs.getZoneFromTextID(cell)
-        )
+    def cell_to_point(self, cell) -> shapely.geometry.Point:
+        geo_point: dggal.GeoPoint = self.dggrs.getZoneWGS84Centroid(int(cell))
         return shapely.Point(geo_point.lon, geo_point.lat)
 
     def cell_to_polygon(
-        self, cell: str, edgeRefinement: int = 0
+        self, cell, edgeRefinement: int = 0
     ) -> shapely.geometry.Polygon:
         geo_points: list[dggal.GeoPoint] = self.dggrs.getZoneRefinedWGS84Vertices(
-            self.dggrs.getZoneFromTextID(cell), edgeRefinement
+            int(cell), edgeRefinement
         )
         return shapely.Polygon(tuple([(p.lon, p.lat) for p in geo_points]))
 
@@ -282,25 +278,20 @@ class DGGALRasterIndexer(RasterIndexer):
         partition_col = self.partition_col(parent_res)
 
         @lru_cache(maxsize=100000)
-        def get_level(cell_id: str) -> int:
-            return self.dggrs.getZoneLevel(self.dggrs.getZoneFromTextID(cell_id))
+        def get_level(cell_id) -> int:
+            return self.dggrs.getZoneLevel(int(cell_id))
 
         @lru_cache(maxsize=100000)
-        def get_parents(cell_id: str) -> tuple:
-            zone = self.dggrs.getZoneFromTextID(cell_id)
-            return tuple(
-                self.dggrs.getZoneTextID(p) for p in self.dggrs.getZoneParents(zone)
-            )
+        def get_parents(cell_id) -> tuple:
+            return tuple(int(p) for p in self.dggrs.getZoneParents(int(cell_id)))
 
         @lru_cache(maxsize=10000)
-        def get_child_count(parent_id: str) -> int:
-            zone = self.dggrs.getZoneFromTextID(parent_id)
-            return self.dggrs.countSubZones(zone, 1)
+        def get_child_count(parent_id) -> int:
+            return self.dggrs.countSubZones(int(parent_id), 1)
 
-        # Initialise cell data and active set
-        cell_data = {
-            cid: df.loc[cid, [partition_col] + band_cols].to_dict() for cid in df.index
-        }
+        # Column-wise extraction: a row Series would promote uint64 zone IDs
+        # to float64 alongside the float bands, rounding them.
+        cell_data = df[[partition_col] + band_cols].to_dict("index")
         active_cells = set(df.index)
 
         # Compact level by level from fine to coarse
@@ -369,7 +360,10 @@ class DGGALRasterIndexer(RasterIndexer):
             for cid in active_cells
         ]
 
-        return pd.DataFrame(result_data).set_index(index_col)
+        result = pd.DataFrame(result_data).set_index(index_col)
+        result.index = result.index.astype(df.index.dtype)
+        result[partition_col] = result[partition_col].astype(df[partition_col].dtype)
+        return result
 
 
 class ISEA4RRasterIndexer(DGGALRasterIndexer):

--- a/raster2dggs/indexers/h3rasterindexer.py
+++ b/raster2dggs/indexers/h3rasterindexer.py
@@ -2,6 +2,7 @@ import h3 as h3py
 import h3.api.numpy_int as h3int
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import shapely
 
 from raster2dggs.indexers.rasterindexer import RasterIndexer
@@ -10,14 +11,19 @@ from raster2dggs.indexers.rasterindexer import RasterIndexer
 class H3RasterIndexer(RasterIndexer):
     """
     Provides integration for Uber's H3 DGGS.
+
+    Cells are handled as uint64 throughout; the hexadecimal form is produced
+    only at the output boundary via cells_to_string.
     """
 
+    CELL_ARROW_TYPE: pa.DataType = pa.uint64()
+
+    def cells_to_string(self, cells) -> list:
+        return [h3py.int_to_str(int(c)) for c in cells]
+
     def _index_window(self, wide, resolution: int, parent_res: int):
-        index_col = self.index_col(resolution)
-        partition_col = self.partition_col(parent_res)
-        # Index to integer cells, then resolve each distinct cell's parent and
-        # hex string once. Many pixels fall in the same cell, so those two
-        # steps run on far fewer values than there are pixels.
+        # Many pixels fall in the same cell, so parents are resolved once per
+        # distinct cell.
         cell_ints = np.array(
             [
                 h3int.latlng_to_cell(lat, lon, resolution)
@@ -26,17 +32,14 @@ class H3RasterIndexer(RasterIndexer):
             dtype=np.uint64,
         )
         uniq, inverse = np.unique(cell_ints, return_inverse=True)
-        uniq_hex = np.array([h3py.int_to_str(int(u)) for u in uniq], dtype=object)
-        uniq_parent = np.array(
-            [
-                h3py.int_to_str(int(h3int.cell_to_parent(int(u), parent_res)))
-                for u in uniq
-            ],
-            dtype=object,
+        uniq_parent = np.fromiter(
+            (h3int.cell_to_parent(int(u), parent_res) for u in uniq),
+            dtype=np.uint64,
+            count=len(uniq),
         )
         wide = wide.drop(columns=["x", "y"])
-        wide[index_col] = uniq_hex[inverse]
-        wide[partition_col] = uniq_parent[inverse]
+        wide[self.index_col(resolution)] = uniq[inverse]
+        wide[self.partition_col(parent_res)] = uniq_parent[inverse]
         return wide.reset_index(drop=True)
 
     @staticmethod
@@ -46,36 +49,38 @@ class H3RasterIndexer(RasterIndexer):
 
         Implementation of interface function.
         """
-        current_resolution = h3py.get_resolution(cell)
+        current_resolution = h3int.get_resolution(int(cell))
         n = desired_resolution - current_resolution
-        if h3py.is_pentagon(cell):
+        if h3int.is_pentagon(int(cell)):
             return 1 + 5 * (7**n - 1) // 6
         else:
             return 7**n
 
     @staticmethod
-    def valid_set(cells: set) -> set[str]:
+    def valid_set(cells: set) -> set:
         """
         Implementation of interface function.
         """
-        return set(filter(lambda c: (not pd.isna(c)) and h3py.is_valid_cell(c), cells))
+        return set(
+            filter(lambda c: (not pd.isna(c)) and h3int.is_valid_cell(int(c)), cells)
+        )
 
     @staticmethod
     def parent_cells(cells: set, resolution) -> map:
         """
         Implementation of interface function.
         """
-        return map(lambda x: h3py.cell_to_parent(x, resolution), cells)
+        return map(lambda x: h3int.cell_to_parent(int(x), resolution), cells)
 
-    def expected_count(self, parent: str, resolution: int):
+    def expected_count(self, parent, resolution: int):
         """
         Implementation of interface function.
         """
         return self.cell_to_children_size(parent, resolution)
 
     def cell_area_m2(self, resolution: int, lat: float, lon: float) -> float:
-        cell = h3py.latlng_to_cell(lat, lon, resolution)
-        return h3py.cell_area(cell, unit="m^2")
+        cell = h3int.latlng_to_cell(lat, lon, resolution)
+        return h3int.cell_area(cell, unit="m^2")
 
     SUPPORTS_CELL_ENUMERATION: bool = True
 
@@ -100,19 +105,19 @@ class H3RasterIndexer(RasterIndexer):
                 (min_lat, min_lon),
             ]
         )
-        return set(h3py.geo_to_cells(poly, resolution))
+        return {int(c) for c in h3int.geo_to_cells(poly, resolution)}
 
     @staticmethod
     def cells_to_lonlat_arrays(cells: pd.Series) -> tuple[np.ndarray, np.ndarray]:
-        arr = np.array([h3py.cell_to_latlng(c) for c in cells])
+        arr = np.array([h3int.cell_to_latlng(int(c)) for c in cells])
         return arr[:, 1], arr[:, 0]  # lons, lats
 
     @staticmethod
-    def cell_to_point(cell: str) -> shapely.geometry.Point:
-        return shapely.Point(h3py.cell_to_latlng(cell)[::-1])
+    def cell_to_point(cell) -> shapely.geometry.Point:
+        return shapely.Point(h3int.cell_to_latlng(int(cell))[::-1])
 
     @staticmethod
-    def cell_to_polygon(cell: str) -> shapely.geometry.Polygon:
+    def cell_to_polygon(cell) -> shapely.geometry.Polygon:
         return shapely.Polygon(
-            tuple(coord[::-1] for coord in h3py.cell_to_boundary(cell))
+            tuple(coord[::-1] for coord in h3int.cell_to_boundary(int(cell)))
         )

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -496,18 +496,25 @@ class RasterIndexer(IRasterIndexer):
             for parent, group in parent_groups:
                 if isinstance(parent, tuple) and len(parent) == 1:
                     parent = parent[0]
+                if pd.api.types.is_unsigned_integer_dtype(df.index.dtype):
+                    # A Python-int label re-infers a one-row index as int64,
+                    # and int64 concatenated with uint64 promotes to float64,
+                    # rounding cell IDs.
+                    parent = np.uint64(parent)
                 if parent in compaction_map:
                     continue
                 expected_count = self.expected_count(parent, resolution)
                 if len(group) == expected_count and all(
                     _col_is_uniform(group[c]) for c in band_cols
                 ):
-                    compact_row = group.iloc[0]
-                    compact_row.name = parent  # Rename the index to the parent cell
+                    # A one-row frame, not a row Series: extracting a row mixes
+                    # the cell columns with float bands and promotes uint64 cell
+                    # IDs to float64, which rounds them.
+                    compact_row = group.iloc[[0]].rename(index={group.index[0]: parent})
                     compaction_map[parent] = compact_row
                     unprocessed_indices -= set(group.index)
-        compacted_df = pd.DataFrame(list(compaction_map.values()))
         remaining_df = df.loc[list(unprocessed_indices)]
-        result_df = pd.concat([compacted_df, remaining_df])
+        result_df = pd.concat(list(compaction_map.values()) + [remaining_df])
         result_df = result_df.rename_axis(df.index.name)
+        result_df.index = result_df.index.astype(df.index.dtype)
         return result_df

--- a/raster2dggs/indexers/s2rasterindexer.py
+++ b/raster2dggs/indexers/s2rasterindexer.py
@@ -3,6 +3,7 @@ from math import ceil
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import s2sphere
 import shapely
 
@@ -13,19 +14,30 @@ from raster2dggs.indexers.rasterindexer import RasterIndexer
 class S2RasterIndexer(RasterIndexer):
     """
     Provides integration for Google's S2 DGGS.
+
+    Cells are handled as uint64 CellId values throughout; tokens are produced
+    only at the output boundary via cells_to_string. Note tokens are not plain
+    hex of the id -- trailing zeros are stripped -- and ids on faces 4 and 5
+    exceed int64, which is why the working type is unsigned.
     """
+
+    CELL_ARROW_TYPE: pa.DataType = pa.uint64()
+
+    def cells_to_string(self, cells) -> list:
+        return [s2sphere.CellId(int(c)).to_token() for c in cells]
 
     def _index_window(self, wide, resolution: int, parent_res: int):
         cells = [
             s2sphere.CellId.from_lat_lng(s2sphere.LatLng.from_degrees(lat, lon))
             for lat, lon in zip(wide["y"], wide["x"], strict=True)
         ]
+        n = len(cells)
         wide = wide.drop(columns=["x", "y"])
-        wide[self.index_col(resolution)] = pd.Series(
-            [c.parent(resolution).to_token() for c in cells], index=wide.index
+        wide[self.index_col(resolution)] = np.fromiter(
+            (c.parent(resolution).id() for c in cells), dtype=np.uint64, count=n
         )
-        wide[self.partition_col(parent_res)] = pd.Series(
-            [c.parent(parent_res).to_token() for c in cells], index=wide.index
+        wide[self.partition_col(parent_res)] = np.fromiter(
+            (c.parent(parent_res).id() for c in cells), dtype=np.uint64, count=n
         )
         return wide
 
@@ -46,20 +58,14 @@ class S2RasterIndexer(RasterIndexer):
         return 4 ** (desired_resolution - cell_level)
 
     @staticmethod
-    def valid_set(cells: set) -> set[str]:
+    def valid_set(cells: set) -> set:
         """
         Implementation of interface function.
         """
         return set(
-            map(
-                lambda c: c.to_token(),
-                filter(
-                    lambda c: c.is_valid(),
-                    map(
-                        lambda c: s2sphere.CellId.from_token(c),
-                        filter(lambda c: not pd.isna(c), cells),
-                    ),
-                ),
+            filter(
+                lambda c: (not pd.isna(c)) and s2sphere.CellId(int(c)).is_valid(),
+                cells,
             )
         )
 
@@ -69,19 +75,15 @@ class S2RasterIndexer(RasterIndexer):
         Implementation of interface function.
         """
         return map(
-            lambda token: s2sphere.CellId.from_token(token)
-            .parent(resolution)
-            .to_token(),
+            lambda c: s2sphere.CellId(int(c)).parent(resolution).id(),
             cells,
         )
 
-    def expected_count(self, parent: str, resolution: int):
+    def expected_count(self, parent, resolution: int):
         """
         Implementation of interface function.
         """
-        return self.cell_to_children_size(
-            s2sphere.CellId.from_token(parent), resolution
-        )
+        return self.cell_to_children_size(s2sphere.CellId(int(parent)), resolution)
 
     SUPPORTS_CELL_ENUMERATION: bool = True
 
@@ -130,7 +132,7 @@ class S2RasterIndexer(RasterIndexer):
             lat = ll.lat().degrees
             lon = ll.lng().degrees
             if min_lat <= lat <= max_lat and min_lon <= lon <= max_lon:
-                result.add(cell_id.to_token())
+                result.add(cell_id.id())
         return result
 
     def cell_area_m2(self, resolution: int, lat: float, lon: float) -> float:
@@ -146,7 +148,7 @@ class S2RasterIndexer(RasterIndexer):
             [
                 (ll.lng().degrees, ll.lat().degrees)
                 for ll in (
-                    s2sphere.LatLng.from_point(s2sphere.CellId.from_token(c).to_point())
+                    s2sphere.LatLng.from_point(s2sphere.CellId(int(c)).to_point())
                     for c in cells
                 )
             ]
@@ -154,13 +156,13 @@ class S2RasterIndexer(RasterIndexer):
         return pts[:, 0], pts[:, 1]  # lons, lats
 
     @staticmethod
-    def cell_to_point(cell: str) -> shapely.geometry.Point:
-        latLng = s2sphere.LatLng.from_point(s2sphere.CellId.from_token(cell).to_point())
+    def cell_to_point(cell) -> shapely.geometry.Point:
+        latLng = s2sphere.LatLng.from_point(s2sphere.CellId(int(cell)).to_point())
         return shapely.Point(latLng.lng().degrees, latLng.lat().degrees)
 
     @staticmethod
-    def cell_to_polygon(cell: str) -> shapely.geometry.Polygon:
-        cell_id = s2sphere.CellId.from_token(cell)
+    def cell_to_polygon(cell) -> shapely.geometry.Polygon:
+        cell_id = s2sphere.CellId(int(cell))
         cell = s2sphere.Cell(cell_id)
         vertices = []
         for i in range(4):

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -17,11 +17,44 @@ class IRasterIndexer:
         interface instead.
     """
 
+    #: Arrow type of the working cell-ID representation. Backends with a native
+    #: integer form (H3, S2, A5, DGGAL) override with pa.uint64() and carry
+    #: integers through the whole pipeline; conversion to the text form happens
+    #: once, at the output boundary, unless the user asks for --cell-id uint64.
+    CELL_ARROW_TYPE: pa.DataType = pa.string()
+
     def __init__(self, dggs: str):
         """
         Value used across all child classes
         """
         self.dggs = dggs
+
+    @property
+    def cell_pd_dtype(self) -> str:
+        """Pandas dtype of the working cell-ID representation."""
+        return "uint64" if self.CELL_ARROW_TYPE == pa.uint64() else "string"
+
+    def cells_to_string(self, cells) -> list:
+        """
+        Convert working-form cell IDs to the DGGS's string form (hex for H3/A5,
+        tokens for S2, structured IDs for DGGAL). Identity for backends whose
+        working form is already a string.
+        """
+        return list(cells)
+
+    def cell_array(self, values):
+        """Working-form cell values as a column-ready array.
+
+        Integer backends get an explicit uint64 array: pandas would otherwise
+        infer int64 from a list of Python ints, which overflows for S2 cells on
+        faces 4 and 5.
+        """
+        values = list(values)
+        if self.CELL_ARROW_TYPE == pa.uint64():
+            return np.fromiter(
+                (int(v) for v in values), dtype=np.uint64, count=len(values)
+            )
+        return values
 
     def index_col(self, resolution: int) -> str:
         """

--- a/raster2dggs/transfers/interpolation.py
+++ b/raster2dggs/transfers/interpolation.py
@@ -184,9 +184,9 @@ class _SampleIndexer:
             )
         index_col = self.indexer.index_col(self.resolution)
         partition_col = self.indexer.partition_col(self.parent_res)
-        wide[index_col] = cells
+        wide[index_col] = self.indexer.cell_array(cells)
         with PROFILER.phase("stage1.parent_cells"):
-            wide[partition_col] = list(
+            wide[partition_col] = self.indexer.cell_array(
                 self.indexer.single_parent_cells(cells, self.parent_res)
             )
         if self.nodata_policy.lower() == "omit":

--- a/raster2dggs/transfers/overlay.py
+++ b/raster2dggs/transfers/overlay.py
@@ -414,9 +414,18 @@ class _OverlayIndexer:
                 _fix_antimeridian(self.indexer.cell_to_polygon(c)) for c in cells
             ]
         # WGS84 GDF for VCT shapely area computation (raster_fracs).
+        # exactextract carries a positional feature id rather than the cell ID:
+        # its pybind layer cannot cast uint64 cell values.
         gdf_wgs84 = gpd.GeoDataFrame(
-            {"_cell_id": cells}, geometry=polygons, crs="EPSG:4326"
+            {"_fid": np.arange(len(cells), dtype=np.int32)},
+            geometry=polygons,
+            crs="EPSG:4326",
         )
+
+        def _restore_cell_id(df: pd.DataFrame) -> pd.DataFrame:
+            df["_cell_id"] = self.indexer.cell_array([cells[i] for i in df["_fid"]])
+            return df.drop(columns=["_fid"])
+
         # exactextract does not reliably reproject features to the raster CRS itself;
         # reproject explicitly so intersections are computed in the correct coordinate space.
         gdf = gdf_wgs84.to_crs(self._src_crs)
@@ -452,7 +461,7 @@ class _OverlayIndexer:
                     gdf,
                     main_ops,
                     weights=self._geodesic_weights_path,
-                    include_cols="_cell_id",
+                    include_cols="_fid",
                     output="pandas",
                 )
             else:
@@ -460,9 +469,10 @@ class _OverlayIndexer:
                     self.raster_input,
                     gdf,
                     main_ops,
-                    include_cols="_cell_id",
+                    include_cols="_fid",
                     output="pandas",
                 )
+            result_df = _restore_cell_id(result_df)
 
         valid_frac_by_band = {}
         if is_frac or self._apply_coverage_threshold:
@@ -473,12 +483,14 @@ class _OverlayIndexer:
             # sum to 1.0 regardless of how much of the cell is nodata or outside raster).
             # For threshold: used to null cells below min_valid_coverage.
             with PROFILER.phase("stage1.exactextract"):
-                cov_df = exact_extract(
-                    self._coverage_mask_path,
-                    gdf,
-                    ["mean"],
-                    include_cols="_cell_id",
-                    output="pandas",
+                cov_df = _restore_cell_id(
+                    exact_extract(
+                        self._coverage_mask_path,
+                        gdf,
+                        ["mean"],
+                        include_cols="_fid",
+                        output="pandas",
+                    )
                 ).set_index("_cell_id")
 
             raster_fracs = pd.Series(
@@ -494,7 +506,7 @@ class _OverlayIndexer:
                     )
                     for poly in gdf_wgs84.geometry
                 ],
-                index=pd.Index(cells, name="_cell_id"),
+                index=pd.Index(self.indexer.cell_array(cells), name="_cell_id"),
             )
 
             result_df = result_df.set_index("_cell_id")
@@ -665,9 +677,9 @@ class _OverlayIndexer:
         index_col = self.indexer.index_col(self.resolution)
         partition_col = self.indexer.partition_col(self.parent_res)
         result_cells = result_df["_cell_id"].tolist()
-        result_df[index_col] = result_cells
+        result_df[index_col] = self.indexer.cell_array(result_cells)
         with PROFILER.phase("stage1.parent_cells"):
-            result_df[partition_col] = list(
+            result_df[partition_col] = self.indexer.cell_array(
                 self.indexer.single_parent_cells(result_cells, self.parent_res)
             )
         result_df = result_df.drop(columns=["_cell_id"])

--- a/tests/classes/test_cell_id_modes.py
+++ b/tests/classes/test_cell_id_modes.py
@@ -1,0 +1,93 @@
+"""
+--cell-id: the integer output mode, and the spec/indexer capability agreement.
+"""
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from classes.base import clear_folder
+from classes.helpers import make_raster
+from click.testing import CliRunner
+from data.datapaths import TEST_OUTPUT_PATH
+
+from raster2dggs.cli import cli
+from raster2dggs.cli_factory import SPECS
+from raster2dggs.indexerfactory import indexer_instance
+
+_BOUNDS = (174.0, -41.1, 174.1, -41.0)
+_SIZE = 10
+_RES = 9
+
+
+@pytest.mark.parametrize("spec", SPECS, ids=lambda s: s.name)
+def test_spec_int_cells_agrees_with_indexer(spec):
+    """DGGS_Spec.int_cells drives the CLI choice; CELL_ARROW_TYPE drives the
+    pipeline. They describe the same capability and must not drift."""
+    indexer = indexer_instance(spec.name)
+    assert spec.int_cells == (indexer.CELL_ARROW_TYPE == pa.uint64())
+
+
+class TestCellIdInt:
+    @pytest.fixture(scope="class")
+    def raster(self, tmp_path_factory):
+        path = tmp_path_factory.mktemp("cellid") / "uniform.tif"
+        make_raster(str(path), _BOUNDS, _SIZE, pixel_value=42.0)
+        return str(path)
+
+    def _invoke(self, raster, *extra):
+        if TEST_OUTPUT_PATH.exists():
+            clear_folder(TEST_OUTPUT_PATH)
+        TEST_OUTPUT_PATH.mkdir(exist_ok=True)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "h3",
+                raster,
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                str(_RES),
+                "--processes",
+                "1",
+                "--overwrite",
+                *extra,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        return pq.read_table(TEST_OUTPUT_PATH)
+
+    def test_uint64_mode_writes_uint64_cells(self, raster):
+        table = self._invoke(raster, "--cell-id", "uint64")
+        assert table.schema.field("h3_09").type == pa.uint64()
+
+    def test_uint64_mode_bijects_to_string_mode(self, raster):
+        import h3 as h3py
+
+        text = self._invoke(raster).to_pandas().sort_index()
+        ints = self._invoke(raster, "--cell-id", "uint64").to_pandas()
+        ints.index = pd.Index(
+            [h3py.int_to_str(int(v)) for v in ints.index], name=text.index.name
+        )
+        ints = ints.sort_index()
+
+        assert list(ints.index) == list(text.index)
+        band_cols = [c for c in text.columns if not c.startswith("h3_")]
+        for c in band_cols:
+            assert (ints[c].values == text[c].values).all()
+
+    def test_string_only_dggs_rejects_uint64_at_parse_time(self, raster):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "geohash",
+                raster,
+                str(TEST_OUTPUT_PATH),
+                "-r",
+                "5",
+                "--cell-id",
+                "uint64",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid value for '--cell-id'" in result.output

--- a/tests/classes/test_cells_in_bbox.py
+++ b/tests/classes/test_cells_in_bbox.py
@@ -20,6 +20,7 @@ import importlib
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 _MIN_LON, _MIN_LAT, _MAX_LON, _MAX_LAT = 174.0, -37.0, 175.0, -36.0
@@ -70,10 +71,16 @@ class TestCellsInBbox:
         indexer, resolution = indexer_and_res
         assert len(self._cells(indexer, resolution)) > 0
 
-    def test_cell_ids_are_strings(self, indexer_and_res):
+    def test_cell_ids_match_working_form(self, indexer_and_res):
+        """Cell IDs are ints for backends with a native integer form
+        (CELL_ARROW_TYPE uint64), text for the rest."""
         indexer, resolution = indexer_and_res
+        expect_int = indexer.CELL_ARROW_TYPE == pa.uint64()
         for c in self._cells(indexer, resolution):
-            assert isinstance(c, str), f"Cell ID {c!r} should be a string"
+            if expect_int:
+                assert isinstance(c, (int, np.integer)), f"{c!r} should be an int"
+            else:
+                assert isinstance(c, str), f"Cell ID {c!r} should be a string"
 
     def test_all_centroids_inside_bbox(self, indexer_and_res):
         indexer, resolution = indexer_and_res

--- a/tests/regression/test_a5_cells_in_bbox_coverage.py
+++ b/tests/regression/test_a5_cells_in_bbox_coverage.py
@@ -72,7 +72,7 @@ def _expected_cells(min_lon, min_lat, max_lon, max_lat, resolution, step=_GRID_S
         clon, clat = a5.cell_to_lonlat(cell)
         clon = (clon + 180.0) % 360.0 - 180.0
         if min_lat <= clat <= max_lat and min_lon <= clon <= max_lon:
-            expected.add(a5.u64_to_hex(cell))
+            expected.add(int(cell))
     return expected
 
 

--- a/tests/regression/test_a5_thread_safety.py
+++ b/tests/regression/test_a5_thread_safety.py
@@ -96,35 +96,35 @@ def test_cell_area_m2_holds_lock(indexer, assert_locked_during):
 
 def test_valid_set_holds_lock(indexer, assert_locked_during):
     assert_locked_during("get_resolution")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     indexer.valid_set({cell})
 
 
 def test_parent_cells_holds_lock(indexer, assert_locked_during):
     assert_locked_during("cell_to_parent")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     list(indexer.parent_cells({cell}, 2))
 
 
 def test_expected_count_holds_lock(indexer, assert_locked_during):
-    assert_locked_during("hex_to_u64")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    assert_locked_during("get_resolution")
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     indexer.expected_count(cell, 8)
 
 
 def test_cells_to_lonlat_arrays_holds_lock(indexer, assert_locked_during):
     assert_locked_during("cell_to_lonlat")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     indexer.cells_to_lonlat_arrays(pd.Series([cell]))
 
 
 def test_cell_to_point_holds_lock(indexer, assert_locked_during):
     assert_locked_during("cell_to_lonlat")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     indexer.cell_to_point(cell)
 
 
 def test_cell_to_polygon_holds_lock(indexer, assert_locked_during):
     assert_locked_during("cell_to_boundary")
-    cell = a5.u64_to_hex(a5.lonlat_to_cell((170.5, -40.5), 6))
+    cell = int(a5.lonlat_to_cell((170.5, -40.5), 6))
     indexer.cell_to_polygon(cell)

--- a/tests/regression/test_s2_cells_in_bbox_coverage.py
+++ b/tests/regression/test_s2_cells_in_bbox_coverage.py
@@ -71,7 +71,7 @@ def _expected_cells(min_lon, min_lat, max_lon, max_lat, resolution, step=_GRID_S
         ll = s2sphere.LatLng.from_point(cell_id.to_point())
         clat, clon = ll.lat().degrees, ll.lng().degrees
         if min_lat <= clat <= max_lat and min_lon <= clon <= max_lon:
-            expected.add(cell_id.to_token())
+            expected.add(cell_id.id())
     return expected
 
 

--- a/tests/regression/test_stage2_partitioning.py
+++ b/tests/regression/test_stage2_partitioning.py
@@ -38,7 +38,12 @@ def stage1_store(tmp_path):
     store = tmp_path / "stage1"
     values: dict[str, list[float]] = {}
     for parent in range(_PARENTS):
-        cells = [f"8{parent:x}bb{i:010d}" for i in range(_CELLS_PER_PARENT)]
+        # Synthetic uint64 IDs in H3's working form; values need only be
+        # distinct and groupable.
+        cells = np.array(
+            [(0x8000 + parent) * 10**12 + i for i in range(_CELLS_PER_PARENT)],
+            dtype=np.uint64,
+        )
         for file_no in range(_FILES_PER_PARENT):
             # A distinct value per (cell, file), so a partial mean is detectable.
             vals = np.array(
@@ -46,14 +51,15 @@ def stage1_store(tmp_path):
                 dtype=np.float64,
             )
             for cell, v in zip(cells, vals, strict=True):
-                values.setdefault(cell, []).append(float(v))
+                values.setdefault(int(cell), []).append(float(v))
             pq.write_to_dataset(
                 pa.table(
                     {
                         "band_1": vals,
                         index_col: cells,
-                        partition_col: [f"8{parent:x}bbfffffffffff"]
-                        * _CELLS_PER_PARENT,
+                        partition_col: np.full(
+                            _CELLS_PER_PARENT, 0x85000 + parent, dtype=np.uint64
+                        ),
                     }
                 ),
                 root_path=str(store),
@@ -61,7 +67,7 @@ def stage1_store(tmp_path):
                 basename_template=f"{file_no}." + "{i}.parquet",
                 existing_data_behavior="overwrite_or_ignore",
             )
-    return store, {c: float(np.mean(v)) for c, v in values.items()}
+    return store, {int(c): float(np.mean(v)) for c, v in values.items()}
 
 
 def test_one_partition_per_parent(stage1_store):
@@ -69,7 +75,7 @@ def test_one_partition_per_parent(stage1_store):
     size-driven reader puts all six parents in one partition, failing this and
     the next test."""
     store, _ = stage1_store
-    ddf = common._read_stage1_by_parent(store, _partition_col())
+    ddf = common._read_stage1_by_parent(store, _partition_col(), pa.uint64())
 
     assert ddf.npartitions == _PARENTS
 
@@ -78,7 +84,7 @@ def test_no_parent_is_split_across_partitions(stage1_store):
     """The invariant itself: each partition holds exactly one whole parent."""
     store, _ = stage1_store
     partition_col = _partition_col()
-    ddf = common._read_stage1_by_parent(store, partition_col)
+    ddf = common._read_stage1_by_parent(store, partition_col, pa.uint64())
 
     per_partition = ddf.map_partitions(
         lambda df: pd.Series([tuple(sorted(set(df[partition_col])))]),
@@ -121,5 +127,7 @@ def test_each_cell_is_aggregated_once_over_all_its_files(stage1_store, tmp_path)
     got = pq.read_table(output).to_pandas()
     assert len(got) == _PARENTS * _CELLS_PER_PARENT
     assert not got.index.duplicated().any(), "a cell was aggregated more than once"
-    means = got["band_1"].to_dict()
+    # Default output is text: H3's boundary conversion renders the synthetic
+    # uint64 IDs as hex.
+    means = {int(k, 16): v for k, v in got["band_1"].to_dict().items()}
     assert means == pytest.approx(expected)

--- a/tests/regression/test_uint64_cell_ids.py
+++ b/tests/regression/test_uint64_cell_ids.py
@@ -1,0 +1,110 @@
+"""
+Exactness of uint64 cell IDs through the pipeline's pandas machinery.
+
+pandas promotes uint64 to float64 wherever it meets int64 or a float column --
+a row extracted from a mixed frame, a Python-int index label, int64/uint64
+concatenation -- and float64 has 128-step spacing at H3-cell magnitude, so the
+promotion silently corrupts cell IDs into other (usually invalid) cells.
+"""
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import s2sphere
+
+from raster2dggs import common
+from raster2dggs.indexerfactory import indexer_instance
+
+
+def test_compaction_preserves_uint64_cell_ids_exactly():
+    """Compacted parents and their partition values must round-trip exactly.
+
+    The compacted row was extracted with ``group.iloc[0]``, which promotes the
+    whole row -- uint64 cells included -- to float64 alongside the float bands;
+    the parent label then re-inferred the index as int64, and int64 concatenated
+    with uint64 promotes to float64. Either alone corrupts the IDs.
+    """
+    import h3.api.numpy_int as h3i
+
+    h3x = indexer_instance("h3")
+    parent10 = int(h3i.latlng_to_cell(-41.0, 174.0, 10))
+    children = [int(c) for c in h3i.cell_to_children(parent10, 11)]
+    straggler = int(h3i.latlng_to_cell(-41.2, 174.2, 11))
+    p5 = np.uint64(h3i.cell_to_parent(parent10, 5))
+    df = pd.DataFrame(
+        {"h3_05": p5, "band_1": [7.0] * len(children) + [1.0]},
+        index=pd.Index(np.array(children + [straggler], dtype=np.uint64), name="h3_11"),
+    )
+
+    out = h3x.compaction(df, 11, 5)
+
+    got = {int(v) for v in out.index}
+    assert len(out) == 2
+    assert parent10 in got, f"compacted parent corrupted: {[hex(v) for v in got]}"
+    assert straggler in got
+    assert {int(v) for v in out["h3_05"]} == {int(p5)}
+    assert out.index.dtype == np.uint64
+    assert out["h3_05"].dtype == np.uint64
+
+
+def test_s2_face5_parent_survives_the_store_round_trip(tmp_path):
+    """S2 cells on faces 4 and 5 exceed int64. The per-parent read must filter
+    with a typed scalar: a bare Python int past 2^63 overflows pyarrow's
+    default int64 conversion."""
+    face5 = s2sphere.CellId.from_face_pos_level(5, 0, 4).id()
+    assert face5 > 2**63
+    partition_col = "s2_04"
+    pq.write_to_dataset(
+        pa.table(
+            {
+                "band_1": [1.0, 2.0, 3.0],
+                "s2_12": pa.array([10, 11, 12], type=pa.uint64()),
+                partition_col: pa.array([face5, face5, 42], type=pa.uint64()),
+            }
+        ),
+        root_path=str(tmp_path),
+        partition_cols=[partition_col],
+        existing_data_behavior="overwrite_or_ignore",
+    )
+
+    ddf = common._read_stage1_by_parent(tmp_path, partition_col, pa.uint64())
+
+    assert ddf.npartitions == 2
+    got = ddf.compute()
+    assert set(int(v) for v in got[partition_col]) == {face5, 42}
+
+
+def test_cell_columns_never_null():
+    """uint64 columns quietly become float64 (corrupting IDs above 2^53) the
+    moment a null enters them, so Stage 1 must never emit one."""
+    import xarray as xr
+
+    h3x = indexer_instance("h3")
+    values = np.array([[[1.0, np.nan], [np.nan, 4.0]]])
+    block = xr.DataArray(
+        values,
+        dims=("band", "y", "x"),
+        coords={"band": [1], "y": [-41.0, -41.001], "x": [174.0, 174.001]},
+    )
+
+    table = h3x.index_func(block, 11, 5, nodata=np.nan)
+
+    for name in ("h3_11", "h3_05"):
+        col = table[name]
+        assert col.null_count == 0
+        assert col.type == pa.uint64()
+
+
+@pytest.mark.parametrize(
+    "dggs,res", [("h3", 8), ("s2", 12), ("a5", 12), ("isea4r", 12)]
+)
+def test_string_round_trip_is_exact(dggs, res):
+    """cells_to_string must be a faithful rendering of the working IDs."""
+    indexer = indexer_instance(dggs)
+    cells = sorted(indexer.cells_in_bbox(174.0, -41.05, 174.05, -41.0, res))
+    assert cells, "fixture bbox produced no cells"
+    strings = indexer.cells_to_string(cells)
+    assert len(set(strings)) == len(cells), "string forms collide"
+    assert all(isinstance(t, str) for t in strings)


### PR DESCRIPTION
Closes #96. Two commits: the working-form migration, then the flag it enables.

## What this does

For DGGS with a native unsigned 64-bit cell form — **H3, S2, A5, and the 13
DGGAL grids** — cell IDs are now carried as uint64 through Stage 1, the
intermediate store, Stage 2 and compaction, with the string form (hex, token,
text ID) rendered **once at the output boundary**. rHEALPix, Geohash and
Maidenhead have no integer form and are untouched.

`--cell-id [string|uint64]`, default `string`, chooses the output form.
`uint64` writes the columns as unsigned 64-bit integers for consumers that take
them directly — DuckDB's `h3` extension, for one — with no conversion step.

`DGGS_Spec.int_cells` drives a per-DGGS `click.Choice`, so string-only backends
reject `uint64` **at parse time**, with help text that says why:

```
h3:       --cell-id [string|uint64]
geohash:  --cell-id [string]     Geohash cell IDs are strings with no integer
                                 form, so only 'string' is available.
```

A test asserts every spec agrees with its indexer's `CELL_ARROW_TYPE`, so the
two declarations cannot drift.

## Why integers internally, not just at the output

Two reasons, decided deliberately after measurement:

- **Vectorisation groundwork.** Stage 1's dominant remaining cost is per-cell
  Python calls into the DGGS libraries, and any future batched binding operates
  on uint64 arrays — strings cannot be vectorised. h3-py is scalar-only in all
  four API flavours through 4.5.0 (verified against its releases), so the
  binding doesn't exist yet; this makes the pipeline ready for one.
- The measured performance of the representation change alone is roughly
  neutral, as predicted from a prototype before building: single-threaded
  `--sample` ~7% faster (17.7s vs 18.9s on the test DEM; `cells_to_lonlat`
  4.74s → 3.41s), `--point` slightly faster, Stage 2 pays ~0.1–0.35s once for
  the boundary conversion. This is groundwork plus interop, not a speedup.

## The hazard this surfaced: pandas silently corrupts uint64

The headline finding for reviewers. float64 has 128-step spacing at H3-cell
magnitude, and pandas promotes uint64 to float64 wherever it meets int64 or
float values — **rounding cell IDs into different, usually invalid, cells with
no error raised**. Verification caught it twice:

- `group.iloc[0]` in compaction extracts a *row*, promoting uint64 cells
  alongside float bands: compacted parents came out as `...658000` instead of
  `...657fff`. Fixed by extracting one-row *frames* (`iloc[[0]]`), and
  column-wise `to_dict("index")` in the DGGAL 3H variant.
- A Python-int index label re-infers a one-row index as int64, and
  int64+uint64 **concatenation** promotes to float64. Parent labels are now
  coerced to the index dtype.

Related edges, all verified by experiment: a bare Python int past 2^63 (S2
faces 4–5) overflows pyarrow's default filter conversion (typed scalar now);
exactextract's pybind layer cannot carry uint64 feature IDs (overlay routes a
positional `_fid`); a null entering a uint64 column converts it to float64
silently (cell columns are never null, and a test asserts it).

All pinned in `tests/regression/test_uint64_cell_ids.py`.

## Verification

- **Default output byte-identical to master across 36 configurations** —
  every output mode (`value`/`list`/`histogram`, four sample kernels, six
  overlay modes incl. `-vct` and `density-preserve`), `--compact`, `--geo
  point|polygon`, `--decimals`, band selection, multi-aggregation, `--nodata
  emit`, across H3, A5, S2, ISEA4R, ISEA3H — **and the string backends, where
  any change at all would be a machinery regression**. That gate caught a real
  one: an early version changed `large_string` to `string` in the written
  schema even for geohash.
- **uint64 output bijects to string output** through each backend's own
  conversion, including through `--compact` (both compaction variants) and
  `--geo`.
- 512 tests pass (29 new), `black` and `ruff` clean; commit 1 verified to
  stand alone so the history bisects.

## Naming

`string`/`uint64` rather than `text`/`int`: the flag selects the output column
dtype, and these are the words the schema itself uses (`pa.string()`,
`pa.uint64()`), with "hex" wrong across backends (DGGAL text IDs are not hex)
and "token" S2-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
