### PR TITLE
Pin black target-version to py311; apply resulting reformat

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,6 @@ authors:
     given-names: Nicoletta
 repository-code: https://github.com/manaakiwhenua/raster2dggs
 url: https://github.com/manaakiwhenua/raster2dggs
-version: "0.15.1"
+version: "0.15.2"
 date-released: "2026-08-21"
 license: LGPL-3.0-or-later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ pythonpath = ["tests"]
 
 [tool.black]
 line-length = 88
+target-version = ["py311"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raster2dggs"
-version = "0.15.1"
+version = "0.15.2"
 description = "CLI tool to index raster files to DGGS in parallel, writing out to Parquet."
 authors = [
     {name = "James Ardo", email = "ardoj@landcareresearch.co.nz"}

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -1254,9 +1254,10 @@ def initial_index(
                     (w.col_off, w.row_off, w.width, w.height) for w in windows
                 ]
                 try:
-                    with PROFILER.phase("stage1.wall"), tqdm(
-                        total=len(windows), desc="Raster windows"
-                    ) as pbar:
+                    with (
+                        PROFILER.phase("stage1.wall"),
+                        tqdm(total=len(windows), desc="Raster windows") as pbar,
+                    ):
                         if processes > 1:
                             # One snapshot per worker: a worker's totals only
                             # grow, so the last one it sends is its total.


### PR DESCRIPTION
Fixes the black CI failure on the v0.15.1 release.

**Cause:** black infers its target Python versions from \`[project] requires-python\` — a field that only exists since the PEP 621 migration (#101); it never read Poetry's \`python = "^3.11"\`. With \`>=3.11,<4.0\` visible, black now assumes py311+ syntax everywhere and wants the parenthesised multi-context \`with\` form for one pre-existing statement in \`common.py\`. Because inference depends on the black version installed at CI time, the check could drift again with future black/Python releases.

**Fix:**
- Pin \`target-version = ["py311"]\` in \`[tool.black]\` — the minimum target alone determines output style, so pinning the floor matches \`requires-python\` and ruff's \`target-version = "py311"\`, and needs no maintenance as new Python versions appear.
- Apply the one reformat this implies (valid 3.10+ syntax).

\`black --check .\` passes locally (54 files clean); output-schema test module passes (79 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)