### PR TITLE
Accept GDAL /vsi* virtual filesystem paths as raster input

### DIFF
--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -134,7 +134,11 @@ def check_resolutions(resolution: int, parent_res: int) -> None:
 
 def resolve_input_path(raster_input: str | Path) -> str | Path:
     if not Path(raster_input).exists():
-        if not urlparse(raster_input).scheme:
+        # GDAL virtual filesystem paths (/vsicurl/, /vsis3/, chained forms
+        # like /vsizip//vsicurl/...) have no URI scheme but are remote/virtual.
+        if not (
+            str(raster_input).startswith("/vsi") or urlparse(str(raster_input)).scheme
+        ):
             LOGGER.warning(
                 f"Input raster {raster_input} does not exist, and is not recognised as a remote URI"
             )

--- a/tests/classes/test_resolve_input_path.py
+++ b/tests/classes/test_resolve_input_path.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for common.resolve_input_path: local paths are returned as Path,
+remote URIs and GDAL virtual filesystem (/vsi*) paths pass through as str,
+and anything else raises FileNotFoundError.
+"""
+
+import pathlib
+
+import pytest
+
+from raster2dggs import common
+
+
+def test_existing_local_path_returned_as_path(tmp_path):
+    f = tmp_path / "raster.tif"
+    f.touch()
+    result = common.resolve_input_path(str(f))
+    assert isinstance(result, pathlib.Path)
+    assert result == f
+
+
+def test_scheme_uri_passes_through_as_str():
+    uri = "https://example.com/raster.tif"
+    result = common.resolve_input_path(uri)
+    assert isinstance(result, str)
+    assert result == uri
+
+
+@pytest.mark.parametrize(
+    "vsi_path",
+    [
+        "/vsicurl/https://example.com/raster.tif",
+        "/vsis3/bucket/raster.tif",
+        "/vsizip//vsicurl/https://example.com/archive.zip/raster.tif",
+        "/vsimem/raster.tif",
+    ],
+)
+def test_vsi_path_passes_through_as_str(vsi_path):
+    result = common.resolve_input_path(vsi_path)
+    assert isinstance(result, str)
+    assert result == vsi_path
+
+
+def test_missing_local_path_raises():
+    with pytest.raises(FileNotFoundError):
+        common.resolve_input_path("/no/such/raster.tif")


### PR DESCRIPTION
Fixes #103

\`resolve_input_path\` recognised non-local inputs only by URI scheme (\`urlparse(...).scheme\`), so GDAL virtual filesystem paths — which begin with \`/vsi\` and have no scheme — were rejected with \`FileNotFoundError\` before rasterio/GDAL ever saw them. This blocked explicit handlers (\`/vsicurl/\`, \`/vsis3/\`, \`/vsigs/\`, \`/vsimem/\`, ...) and chained forms that have no scheme-based equivalent at all, e.g. \`/vsizip//vsicurl/https://bucket/archive.zip/raster.tif\`.

**Change:** the guard now also accepts any input starting with \`/vsi\`, passing it through as a string exactly like scheme'd URIs. One conditional; no behaviour change for local paths or scheme'd URIs.

**Tests:** new \`tests/classes/test_resolve_input_path.py\` covering local-path → \`Path\`, scheme URI → \`str\` passthrough, four \`/vsi*\` forms (including a chained one) → \`str\` passthrough, and missing local path → \`FileNotFoundError\`. 7 tests, all passing; \`black --check .\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)