### PR TITLE
Make compaction's uniformity check NA-safe for multi-aggregation dicts

### DIFF
--- a/raster2dggs/indexers/dggalrasterindexer.py
+++ b/raster2dggs/indexers/dggalrasterindexer.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 import pyproj
 import shapely
 
-from raster2dggs.indexers.rasterindexer import RasterIndexer
+from raster2dggs.indexers.rasterindexer import RasterIndexer, _freeze
 
 # Instantiate DGGAL
 dggal.pydggal_setup(dggal.Application(appGlobals=globals()))
@@ -320,10 +320,15 @@ class DGGALRasterIndexer(RasterIndexer):
                 if len(children) != get_child_count(parent_id):
                     continue
 
-                # Check if all band values are qual across children
+                # Check if all band values are equal across children. Compared
+                # through _freeze: multi-aggregation dicts may hold pd.NA, on
+                # which plain == raises rather than returning a bool.
                 first_data = cell_data[children[0]]
                 if all(
-                    all(cell_data[c][band] == first_data[band] for c in children)
+                    all(
+                        _freeze(cell_data[c][band]) == _freeze(first_data[band])
+                        for c in children
+                    )
                     for band in band_cols
                 ):
                     # compactable[parent_id] = (children, first_data.copy())

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -19,13 +19,41 @@ def _is_nan(v) -> bool:
         return False
 
 
+# Sentinel standing in for every kind of missing value (pd.NA, None, NaN) in
+# _freeze, so that two missing values compare equal and a missing value compares
+# unequal to a number -- without ever evaluating ``pd.NA == x``, which yields NA
+# rather than a bool and makes dict equality raise.
+_MISSING = object()
+
+
+def _freeze(v):
+    """Hashable, NA-safe key for a cell value: a scalar, a dict/struct (e.g.
+    multi-aggregation ``{'mean': .., 'std': ..}``), or a list (e.g. ``list`` mode)."""
+    if isinstance(v, dict):
+        return tuple((k, _freeze(x)) for k, x in sorted(v.items()))
+    if isinstance(v, (list, tuple, np.ndarray)):
+        return tuple(_freeze(x) for x in v)
+    if v is pd.NA or v is None or _is_nan(v):
+        return _MISSING
+    return v
+
+
 def _col_is_uniform(series: pd.Series) -> bool:
-    """Return True if every value in series is identical. Handles unhashable types (e.g. dicts)."""
+    """Return True if every value in series is identical.
+
+    Scalar columns take pandas' C-level ``nunique`` path. Unhashable values
+    (dicts, lists) are compared through ``_freeze``, which is NA-safe -- nullable
+    aggregates (e.g. ``std`` of a single-pixel cell under ``-d 0``) put ``pd.NA``
+    inside the dicts, and ``dict.__eq__`` on those raises. Sibling groups at
+    coarse compaction levels can hold tens of thousands of cells, so the
+    comparison must short-circuit on the first mismatch as the scalar path does.
+    """
     try:
         return series.nunique(dropna=False) == 1
     except TypeError:
-        first = series.iloc[0]
-        return all(v == first for v in series)
+        it = iter(series)
+        first = _freeze(next(it))
+        return all(_freeze(v) == first for v in it)
 
 
 def _mask_is_nodata(series: pd.Series, nodata) -> pd.Series:

--- a/tests/classes/test_output_schema.py
+++ b/tests/classes/test_output_schema.py
@@ -348,6 +348,19 @@ class TestMultiAgg(TestRunthrough):
         self.assertGreater(len(table), 0)
         self.assertIsInstance(table.schema.field("band_1").type, pa.StructType)
 
+    def test_multi_agg_with_na_in_struct_and_compaction(self):
+        # Regression: at res 8 some cells hold one pixel and their siblings
+        # several; with -d 0 the aggregates are nullable Int64, so a lone
+        # pixel's std is pd.NA inside the dict. Comparing that dict with a
+        # sibling's {"std": 0} raised "boolean value of NA is ambiguous".
+        table = self._run(8, "--agg", "mean,std,min", "-d", "0", "-co")
+        self.assertGreater(len(table), 0)
+        df = table.to_pandas()
+        # Uniform raster: every mean/min must be the pixel value, compacted or not.
+        for row in df["band_1"]:
+            self.assertEqual(row["mean"], _PIXEL_VALUE)
+            self.assertEqual(row["min"], _PIXEL_VALUE)
+
     def test_invalid_agg_name_rejected(self):
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/regression/test_compaction_uniform_na.py
+++ b/tests/regression/test_compaction_uniform_na.py
@@ -1,0 +1,116 @@
+"""
+Compaction's sibling-uniformity check on multi-aggregation values.
+
+With more than one ``-a`` aggregation each band value is a dict, and under
+``-d 0`` the aggregates are nullable ``Int64``, so the ``std`` of a
+single-pixel cell is ``pd.NA`` *inside* the dict. ``dict.__eq__`` then
+evaluates ``pd.NA == <number>`` -> ``NA``, and needing a bool it raises
+``TypeError: boolean value of NA is ambiguous``. Missing-vs-missing must count
+as uniform, missing-vs-number as different, and neither may raise.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from raster2dggs.indexerfactory import indexer_instance
+from raster2dggs.indexers.rasterindexer import _col_is_uniform, _freeze
+
+
+class TestFreeze:
+    def test_missing_values_share_one_key(self):
+        keys = {_freeze(pd.NA), _freeze(None), _freeze(np.nan), _freeze(float("nan"))}
+        assert len(keys) == 1
+
+    def test_missing_differs_from_number(self):
+        assert _freeze(pd.NA) != _freeze(0)
+        assert _freeze(np.nan) != _freeze(0.0)
+
+    def test_dict_key_order_irrelevant(self):
+        assert _freeze({"a": 1, "b": 2}) == _freeze({"b": 2, "a": 1})
+
+    def test_nested_and_list_values_are_hashable(self):
+        v = {"classes": [1, 2], "fractions": [0.5, np.nan], "meta": {"n": pd.NA}}
+        hash(_freeze(v))
+        assert _freeze(v) == _freeze(
+            {"classes": [1, 2], "fractions": [0.5, float("nan")], "meta": {"n": None}}
+        )
+
+
+class TestColIsUniform:
+    def test_scalars(self):
+        assert _col_is_uniform(pd.Series([7.0, 7.0, 7.0]))
+        assert not _col_is_uniform(pd.Series([7.0, 8.0]))
+        assert _col_is_uniform(pd.Series([np.nan, np.nan]))
+        assert not _col_is_uniform(pd.Series([np.nan, 1.0]))
+
+    def test_identical_dicts(self):
+        s = pd.Series([{"mean": 42, "std": 0, "min": 42}] * 3)
+        assert _col_is_uniform(s)
+
+    def test_differing_dicts(self):
+        s = pd.Series([{"mean": 42, "std": 0}, {"mean": 41, "std": 0}])
+        assert not _col_is_uniform(s)
+
+    def test_identical_dicts_with_na(self):
+        s = pd.Series([{"mean": 42, "std": pd.NA}] * 3)
+        assert _col_is_uniform(s)
+
+    def test_na_versus_number_is_not_uniform_and_does_not_raise(self):
+        # The failing case: single-pixel sibling (std NA) beside a multi-pixel one.
+        s = pd.Series([{"mean": 42, "std": pd.NA}, {"mean": 42, "std": 0}])
+        assert not _col_is_uniform(s)
+        # ...regardless of which comes first (dict identity shortcut must not matter).
+        assert not _col_is_uniform(s.iloc[::-1])
+
+    def test_nan_and_na_are_the_same_missing(self):
+        s = pd.Series([{"std": pd.NA}, {"std": np.nan}, {"std": None}])
+        assert _col_is_uniform(s)
+
+    def test_lists(self):
+        assert _col_is_uniform(pd.Series([[1.0, 2.0], [1.0, 2.0]]))
+        assert not _col_is_uniform(pd.Series([[1.0, 2.0], [1.0, 3.0]]))
+
+    def test_none_mixed_with_dicts(self):
+        # Histogram mode can yield None for some cells.
+        assert not _col_is_uniform(pd.Series([None, {"values": [1]}]))
+        assert _col_is_uniform(pd.Series([None, None]))
+
+
+def _h3_sibling_frame(band_values):
+    """Seven res-11 siblings under one res-10 parent plus a straggler, as in
+    tests/regression/test_uint64_cell_ids.py; band values are given per sibling."""
+    import h3.api.numpy_int as h3i
+
+    parent10 = int(h3i.latlng_to_cell(-41.0, 174.0, 10))
+    children = [int(c) for c in h3i.cell_to_children(parent10, 11)]
+    assert len(children) == len(band_values)
+    straggler = int(h3i.latlng_to_cell(-41.2, 174.2, 11))
+    p5 = np.uint64(h3i.cell_to_parent(parent10, 5))
+    df = pd.DataFrame(
+        {"h3_05": p5, "band_1": band_values + [{"mean": 1, "std": pd.NA}]},
+        index=pd.Index(np.array(children + [straggler], dtype=np.uint64), name="h3_11"),
+    )
+    return df, parent10, straggler
+
+
+class TestCompactionWithNAInDicts:
+    def test_identical_na_dicts_compact(self):
+        df, parent10, straggler = _h3_sibling_frame([{"mean": 42, "std": pd.NA}] * 7)
+        out = indexer_instance("h3").compaction(df, 11, 5)
+        assert {int(v) for v in out.index} == {parent10, straggler}
+        assert out.loc[np.uint64(parent10), "band_1"] == {"mean": 42, "std": pd.NA}
+
+    def test_na_beside_number_does_not_compact_and_does_not_raise(self):
+        values = [{"mean": 42, "std": pd.NA}] * 6 + [{"mean": 42, "std": 0}]
+        df, parent10, straggler = _h3_sibling_frame(values)
+        out = indexer_instance("h3").compaction(df, 11, 5)
+        assert len(out) == 8  # nothing compacted
+        assert parent10 not in {int(v) for v in out.index}
+
+    @pytest.mark.parametrize("missing", [np.nan, None])
+    def test_nan_and_na_compact_together(self, missing):
+        values = [{"mean": 42, "std": pd.NA}] * 4 + [{"mean": 42, "std": missing}] * 3
+        df, parent10, straggler = _h3_sibling_frame(values)
+        out = indexer_instance("h3").compaction(df, 11, 5)
+        assert {int(v) for v in out.index} == {parent10, straggler}


### PR DESCRIPTION
Fixes #106

## Problem

\`--compact\` with ≥2 \`-a\` aggregations crashes whenever a sibling group holds a cell whose aggregate has a missing component next to one that doesn't:

```
raster2dggs h3 -r larger-than-pixel -n omit -b 1 -b 2 -b 3 -p 12 --point value \
  -a mean,std,min -d 0 -o -co -g polygon --cell-id uint64 AS24_edge.tiff out.gpq
TypeError: unhashable type: 'dict'            # _col_is_uniform, nunique path
TypeError: boolean value of NA is ambiguous   # _col_is_uniform, fallback path
```

Each band value is a dict (\`{'mean': .., 'std': .., 'min': ..}\`); under \`-d 0\` the nullable \`Int64\` cast makes the \`std\` of a single-pixel cell \`pd.NA\` inside that dict; \`dict.__eq__\` then evaluates \`pd.NA == 0\` → \`NA\`, needs a bool, and raises. (\`{'std': NA} == {'std': NA}\` only survives via the NA-singleton identity shortcut.) Easy to hit with \`larger-than-pixel\` (few pixels per cell).

## Fix

- \`_freeze(v)\`: hashable, NA-safe key — dicts → sorted tuples, lists → tuples, \`pd.NA\`/\`None\`/NaN → one sentinel. Missing-vs-missing is uniform; missing-vs-number is not.
- \`_col_is_uniform\`: keeps pandas' C-level \`nunique\` fast path for scalar columns; for unhashable values compares frozen keys **with early exit on the first mismatch**, matching the old fallback's behaviour. This matters: compaction groups target-resolution cells by ancestor from \`parent_res\` upward, so a group can be \`7^(res − r)\` cells (117,649 at the first level for \`-p 12\`); the check is only reached for complete groups, but those are common on large rasters.
- Same comparison applied to the equivalent \`==\` in \`dggalrasterindexer.py\`'s compaction.

## Tests

- \`tests/regression/test_compaction_uniform_na.py\`: unit tests for \`_freeze\`/\`_col_is_uniform\` (scalars, dicts, NA vs number, NaN≡NA≡None, lists, \`None\` mixed with dicts) and direct \`compaction()\` tests on hand-built H3 sibling frames (identical NA dicts compact; NA beside a number does not compact and does not raise; NaN and NA compact together).
- \`TestMultiAgg::test_multi_agg_with_na_in_struct_and_compaction\`: CLI-level regression (\`--agg mean,std,min -d 0 -co\` at res 8 on the uniform test raster) — verified to crash on master, passes here. The existing \`test_multi_agg_with_compaction\` never produced an NA, hence the gap.

Full suite: 536 passed, 16 skipped. \`black --check .\` clean.

## Verification on the #105 sample (\`AS24_edge.tiff\`)

The command above now completes: 79,272 uncompacted → 45,324 compacted rows (464 compacted parents, mostly the all-zero masked area). All surviving res-12 cells have values identical to the uncompacted run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)