### PR TITLE
Honour GDAL dataset masks (alpha / mask bands) as nodata

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ Options:
                                   defined). Coerced to the output dtype. Note:
                                   non-NaN values participate in cell
                                   aggregation (see -a/--agg).
+  --mask / --no-mask              Honour the raster's GDAL dataset mask (an
+                                  alpha band, or an internal/sidecar .msk mask
+                                  band) as nodata, in addition to any declared
+                                  nodata value. Masked pixels are treated
+                                  exactly like nodata pixels by --nodata
+                                  /--nodata-fill, aggregation and coverage
+                                  accounting. An alpha band that is not
+                                  explicitly selected with -b is consumed as
+                                  the mask and not emitted as a data band.
+                                  --no-mask ignores masks entirely: masked
+                                  pixels are read as ordinary data.  [default:
+                                  mask]
   -c, --compression TEXT          Compression method to use for the output
                                   Parquet files. Options include 'snappy',
                                   'gzip', 'brotli', 'lz4', 'zstd', etc. Use
@@ -354,6 +366,14 @@ gdal_translate -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 input.tif inp
 ```
 
 (If `gdal_translate` warns about the CRS definition not matching the EPSG registry, prefer re-tiling via `rasterio` directly instead, copying `src.profile`/`src.crs` as-is, to avoid GDAL rewriting the projection metadata.)
+
+#### Nodata and dataset masks (`--nodata`, `--mask`)
+
+A pixel is *nodata* if it equals the band's declared nodata value **or** if the raster's GDAL dataset mask marks it invalid — an alpha band, an internal TIFF mask band, or a `.msk` sidecar. Many imagery products (e.g. the LINZ aerial and satellite mosaics) declare no nodata value at all and express coverage solely through an alpha band; without the mask their (0, 0, 0) filler pixels would be averaged into cells along the coverage edge as real black, pulling means toward 0 and inflating spread. raster2dggs therefore honours dataset masks by default, in every sampling mode, and treats masked pixels identically to declared nodata: excluded under `--nodata omit`, written as the fill under `--nodata emit`, excluded from `--agg` statistics, `--overlay` weights and `--valid-coverage-threshold` accounting, and from `--sample` kernels.
+
+When the alpha band is not explicitly requested with `-b`, it is consumed as the mask and **not** emitted as a data band (an RGBA raster yields `band_1`..`band_3`). Select it explicitly (`-b 4`) to also emit it as data — a per-cell coverage feature (note that the alpha band itself is then always valid, so under `--nodata omit` fully masked pixels still produce rows, with NaN in the masked bands and alpha 0). Use `--no-mask` to ignore masks entirely and read masked pixels as ordinary data; the alpha band is then emitted like any other. Rasters whose validity is expressed only by a declared nodata value behave identically either way, and the mask is only read when the source actually carries one.
+
+Value-based nodata is *not* a substitute here: 0 is a legitimate value in imagery (deep shadow, dark water), so declaring it nodata would silently drop real pixels. The mask is exact.
 
 #### Valid-data coverage threshold (`-vct` / `--valid-coverage-threshold`)
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,9 @@ A pixel is *nodata* if it equals the band's declared nodata value **or** if the 
 
 When the alpha band is not explicitly requested with `-b`, it is consumed as the mask and **not** emitted as a data band (an RGBA raster yields `band_1`..`band_3`). Select it explicitly (`-b 4`) to also emit it as data — a per-cell coverage feature (note that the alpha band itself is then always valid, so under `--nodata omit` fully masked pixels still produce rows, with NaN in the masked bands and alpha 0). Use `--no-mask` to ignore masks entirely and read masked pixels as ordinary data; the alpha band is then emitted like any other. Rasters whose validity is expressed only by a declared nodata value behave identically either way, and the mask is only read when the source actually carries one.
 
-Value-based nodata is *not* a substitute here: 0 is a legitimate value in imagery (deep shadow, dark water), so declaring it nodata would silently drop real pixels. The mask is exact.
+Value-based nodata is *not* a substitute here: 0 is a legitimate value in imagery (deep shadow, dark water), so declaring it nodata would silently drop real pixels. The mask is exact. For the same reason, be deliberate with `--nodata emit --nodata-fill`: the fill participates in aggregation, so `--nodata-fill 0` on imagery re-creates exactly the edge bias the mask removes — use it only where the fill has a real meaning (e.g. 0 for sea-level elevation).
+
+Note that GDAL discovers **sidecar** `.msk` masks by listing the raster's directory, so `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` — a common optimisation for remote (`/vsicurl/`, `/vsis3/`) reads — silently disables them. Alpha bands and internal TIFF masks are unaffected; prefer those for remote data, or leave that setting off.
 
 #### Valid-data coverage threshold (`-vct` / `--valid-coverage-threshold`)
 

--- a/raster2dggs/cli_factory.py
+++ b/raster2dggs/cli_factory.py
@@ -209,6 +209,7 @@ def run_index(
     band,
     nodata_policy: str,
     emit_nodata_value: float | None,
+    use_mask: bool,
     compression: str,
     processes: int,
     agg,
@@ -253,6 +254,7 @@ def run_index(
         hist_weight,
         hist_normalize,
         cell_id,
+        use_mask=use_mask,
     )
 
     PROFILER.reset(enabled=profile)
@@ -342,6 +344,19 @@ def make_command(spec: DGGS_Spec):
             "If omitted, the source raster nodata value is used (NaN if none is defined). "
             "Coerced to the output dtype. "
             "Note: non-NaN values participate in cell aggregation (see -a/--agg)."
+        ),
+    )
+    @click.option(
+        "--mask/--no-mask",
+        "use_mask",
+        default=const.DEFAULTS["use_mask"],
+        show_default=True,
+        help=(
+            "Honour the raster's GDAL dataset mask (an alpha band, or an internal/sidecar .msk mask band) "
+            "as nodata, in addition to any declared nodata value. Masked pixels are treated exactly like "
+            "nodata pixels by --nodata/--nodata-fill, aggregation and coverage accounting. An alpha band "
+            "that is not explicitly selected with -b is consumed as the mask and not emitted as a data band. "
+            "--no-mask ignores masks entirely: masked pixels are read as ordinary data."
         ),
     )
     @click.option(
@@ -563,6 +578,7 @@ def make_command(spec: DGGS_Spec):
         band,
         nodata_policy,
         emit_nodata_value,
+        use_mask,
         compression,
         processes,
         agg,
@@ -646,6 +662,7 @@ def make_command(spec: DGGS_Spec):
             band,
             nodata_policy,
             emit_nodata_value,
+            use_mask,
             compression,
             processes,
             agg,

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -28,6 +28,7 @@ import pyproj
 import rasterio as rio
 import rioxarray
 import shapely
+from rasterio.enums import ColorInterp, MaskFlags
 from rasterio.warp import transform_bounds
 from tqdm import tqdm
 from tqdm.dask import TqdmCallback
@@ -39,7 +40,7 @@ from raster2dggs.interfaces import IRasterIndexer
 from raster2dggs.profiling import PROFILER
 from raster2dggs.transfers.assign_centers import _AssignCentersIndexer
 from raster2dggs.transfers.interpolation import _SampleIndexer
-from raster2dggs.transfers.overlay import _OverlayIndexer
+from raster2dggs.transfers.overlay import _OverlayIndexer, masked_raster_sources
 
 LOGGER = logging.getLogger(__name__)
 click_log.basic_config(LOGGER)
@@ -313,6 +314,7 @@ def assemble_kwargs(
     hist_weight: str = "count",
     hist_normalize: str = "none",
     cell_id: str = "string",
+    use_mask: bool = True,
 ) -> dict:
     return {
         "compression": compression,
@@ -332,6 +334,7 @@ def assemble_kwargs(
         "hist_weight": hist_weight,
         "hist_normalize": hist_normalize,
         "cell_id": cell_id,
+        "use_mask": use_mask,
     }
 
 
@@ -937,6 +940,18 @@ class _ParquetWriter:
             )
 
 
+def _needs_mask_read(src: rio.DatasetReader, selected_indices) -> bool:
+    """True if any selected band's validity comes from a mask band -- an alpha
+    band or an internal/sidecar mask -- rather than only from a declared nodata
+    value. Nodata alone is already handled by value, so reading the mask for it
+    would be pure overhead."""
+    flags = src.mask_flag_enums
+    return any(
+        MaskFlags.alpha in flags[i - 1] or MaskFlags.per_dataset in flags[i - 1]
+        for i in selected_indices
+    )
+
+
 def _setup_stage1_worker(cfg: dict) -> None:
     """Build this process's transfer context from picklable configuration.
 
@@ -949,6 +964,9 @@ def _setup_stage1_worker(cfg: dict) -> None:
     env = rio.Env()
     env.__enter__()
     src = rio.open(cfg["raster_input"], mode="r", sharing=False)
+    # .get: cfg is internal, and callers building it by hand predate use_mask.
+    use_mask = cfg.get("use_mask", True)
+    apply_mask = use_mask and _needs_mask_read(src, cfg["selected_indices"])
     indexer = idxfactory.indexer_instance(cfg["dggs"])
     write_result = _ParquetWriter(
         tmpdir=cfg["tmpdir"],
@@ -968,6 +986,17 @@ def _setup_stage1_worker(cfg: dict) -> None:
 
     da = None
     if cfg["transfer"] in const.OVERLAY_TRANSFER_KEYS:
+        # Only a source with an alpha/mask band needs anything other than the
+        # raster path: masked NaN-float sources with --mask (exactextract's own
+        # masked-array handling is unreliable), raw pixel values with --no-mask.
+        raster_source = None
+        if _needs_mask_read(src, range(1, src.count + 1)):
+            if use_mask:
+                raster_source = masked_raster_sources(src, cfg["selected_indices"])
+            else:
+                raster_source = rioxarray.open_rasterio(
+                    src, masked=False, default_name=const.DEFAULT_NAME
+                )
         ctx = _OverlayIndexer(
             raster_input=cfg["raster_input"],
             op=cfg["op"],
@@ -975,6 +1004,8 @@ def _setup_stage1_worker(cfg: dict) -> None:
             min_valid_coverage=cfg["min_valid_coverage"],
             decimals=cfg["decimals"],
             hist_spec=cfg["hist_spec"],
+            use_mask=use_mask,
+            raster_source=raster_source,
             **cfg["overlay_shared_paths"],
             **shared,
         )
@@ -1002,6 +1033,7 @@ def _setup_stage1_worker(cfg: dict) -> None:
                 da=da,
                 inverse_transformer=transformer,
                 nodata=src.nodata,
+                apply_mask=apply_mask,
                 **shared,
             )
             func = {
@@ -1014,7 +1046,12 @@ def _setup_stage1_worker(cfg: dict) -> None:
                 src.crs, "EPSG:4326", always_xy=True
             )
             ctx = _AssignCentersIndexer(
-                da=da, nodata=src.nodata, transformer=transformer, **shared
+                da=da,
+                nodata=src.nodata,
+                transformer=transformer,
+                src=src,
+                apply_mask=apply_mask,
+                **shared,
             )
             func = ctx.process_window
 
@@ -1153,8 +1190,28 @@ def initial_index(
                     )
                     for i in range(1, count + 1)
                 }
+                use_mask = bool(kwargs.get("use_mask", True))
                 if not bands:  # Covers None or empty tuple
                     selected_indices = list(range(1, count + 1))
+                    if use_mask:
+                        # An alpha band expresses validity, not data: with masks
+                        # honoured it is consumed as the dataset mask rather than
+                        # emitted. Selecting it explicitly with -b still emits it.
+                        alpha = [
+                            i
+                            for i in selected_indices
+                            if src.colorinterp[i - 1] == ColorInterp.alpha
+                        ]
+                        if alpha and len(alpha) < len(selected_indices):
+                            LOGGER.info(
+                                "Alpha band(s) %s used as the dataset mask and not "
+                                "emitted; select explicitly with -b to emit as data "
+                                "(or pass --no-mask)",
+                                alpha,
+                            )
+                            selected_indices = [
+                                i for i in selected_indices if i not in alpha
+                            ]
                 else:
                     if all(isinstance(b, int) or str(b).isdigit() for b in bands):
                         selected_indices = list(map(int, bands))
@@ -1212,6 +1269,7 @@ def initial_index(
                     "selected_labels": selected_labels,
                     "nodata_policy": nodata_policy,
                     "emit_nodata_value": emit_nodata_value,
+                    "use_mask": use_mask,
                     "transfer": kwargs["transfer"],
                     "interp": kwargs.get("interp", const.Interp.NN),
                     "op": kwargs.get("op"),
@@ -1251,6 +1309,7 @@ def initial_index(
                         min_valid_coverage=cfg["min_valid_coverage"],
                         decimals=cfg["decimals"],
                         hist_spec=cfg["hist_spec"],
+                        use_mask=use_mask,
                     )
                     cfg["overlay_shared_paths"] = shared_overlay.shared_temp_paths()
 

--- a/raster2dggs/common.py
+++ b/raster2dggs/common.py
@@ -40,7 +40,11 @@ from raster2dggs.interfaces import IRasterIndexer
 from raster2dggs.profiling import PROFILER
 from raster2dggs.transfers.assign_centers import _AssignCentersIndexer
 from raster2dggs.transfers.interpolation import _SampleIndexer
-from raster2dggs.transfers.overlay import _OverlayIndexer, masked_raster_sources
+from raster2dggs.transfers.overlay import (
+    _OverlayIndexer,
+    masked_raster_sources,
+    raw_raster_sources,
+)
 
 LOGGER = logging.getLogger(__name__)
 click_log.basic_config(LOGGER)
@@ -990,13 +994,9 @@ def _setup_stage1_worker(cfg: dict) -> None:
         # raster path: masked NaN-float sources with --mask (exactextract's own
         # masked-array handling is unreliable), raw pixel values with --no-mask.
         raster_source = None
-        if _needs_mask_read(src, range(1, src.count + 1)):
-            if use_mask:
-                raster_source = masked_raster_sources(src, cfg["selected_indices"])
-            else:
-                raster_source = rioxarray.open_rasterio(
-                    src, masked=False, default_name=const.DEFAULT_NAME
-                )
+        if _needs_mask_read(src, cfg["selected_indices"]):
+            make_sources = masked_raster_sources if use_mask else raw_raster_sources
+            raster_source = make_sources(src, cfg["selected_indices"])
         ctx = _OverlayIndexer(
             raster_input=cfg["raster_input"],
             op=cfg["op"],
@@ -1012,9 +1012,13 @@ def _setup_stage1_worker(cfg: dict) -> None:
         func = ctx.process_window
         transformer = None
     else:
+        # One lock guards every read of ``src`` in this process -- rioxarray's
+        # and the transfers' mask reads alike; GDAL datasets are not safe for
+        # concurrent access.
+        read_lock = dask.utils.SerializableLock()
         da = rioxarray.open_rasterio(
             src,
-            lock=dask.utils.SerializableLock(),
+            lock=read_lock,
             masked=False,
             default_name=const.DEFAULT_NAME,
         ).chunk(**{"y": "auto", "x": "auto"})
@@ -1034,6 +1038,7 @@ def _setup_stage1_worker(cfg: dict) -> None:
                 inverse_transformer=transformer,
                 nodata=src.nodata,
                 apply_mask=apply_mask,
+                read_lock=read_lock,
                 **shared,
             )
             func = {
@@ -1051,6 +1056,7 @@ def _setup_stage1_worker(cfg: dict) -> None:
                 transformer=transformer,
                 src=src,
                 apply_mask=apply_mask,
+                read_lock=read_lock,
                 **shared,
             )
             func = ctx.process_window

--- a/raster2dggs/constants.py
+++ b/raster2dggs/constants.py
@@ -87,6 +87,7 @@ DEFAULTS = {
     "geo": "none",
     "tempdir": tempfile.tempdir,
     "nodata_policy": "omit",
+    "use_mask": True,
 }
 
 

--- a/raster2dggs/indexers/rasterindexer.py
+++ b/raster2dggs/indexers/rasterindexer.py
@@ -154,6 +154,7 @@ class RasterIndexer(IRasterIndexer):
         emit_nodata_value: Number | None = None,
         transformer=None,
         selected_indices: tuple[int] = None,
+        valid_mask: np.ndarray | None = None,
     ) -> pa.Table:
         if nodata_policy.lower() not in ("omit", "emit"):
             raise ValueError(f"Unknown nodata policy: {nodata_policy}")
@@ -169,6 +170,13 @@ class RasterIndexer(IRasterIndexer):
         if not np.issubdtype(values.dtype, np.floating):
             values = values.astype(np.float64)
         flat = values.reshape(n_bands, height * width)
+        # Dataset-mask validity (alpha / mask band), (bands, h, w) with True
+        # meaning valid; masked pixels are treated exactly like nodata below.
+        invalid_flat = (
+            None
+            if valid_mask is None
+            else ~np.asarray(valid_mask, dtype=bool).reshape(n_bands, height * width)
+        )
 
         with PROFILER.phase("stage1.reshape"):
             emit_mode = nodata_policy.lower() == "emit"
@@ -178,8 +186,10 @@ class RasterIndexer(IRasterIndexer):
             )
 
             cols = {}
-            for band_id, col in zip(band_ids, flat, strict=True):
+            for i, (band_id, col) in enumerate(zip(band_ids, flat, strict=True)):
                 mask = _mask_is_nodata_array(col, nodata)
+                if invalid_flat is not None:
+                    mask |= invalid_flat[i]
                 if mask.any():
                     col = col.copy()
                     col[mask] = np.nan if emit_fill is None else emit_fill

--- a/raster2dggs/interfaces.py
+++ b/raster2dggs/interfaces.py
@@ -109,6 +109,7 @@ class IRasterIndexer:
         emit_nodata_value: Number | None = None,
         transformer=None,
         selected_indices: tuple[int] = None,
+        valid_mask: np.ndarray | None = None,
     ) -> pa.Table:
         """
         Function for primary indexation.

--- a/raster2dggs/transfers/assign_centers.py
+++ b/raster2dggs/transfers/assign_centers.py
@@ -1,8 +1,8 @@
 """
 Raster assign_centers context for --transfer assign_centers (the default).
 
-_AssignCentersIndexer holds all shared state and exposes process_window as a bound
-method callable by ThreadPoolExecutor.map.
+_AssignCentersIndexer holds all shared state and exposes process_window, called
+once per raster window in a Stage 1 worker process.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ from raster2dggs.profiling import PROFILER
 class _AssignCentersIndexer:
     """Shared context for --transfer assign_centers.
 
-    Instantiate once; pass ctx.process_window to ThreadPoolExecutor.map.
+    Instantiate once per worker process; call ctx.process_window per window.
     """
 
     da: xr.DataArray
@@ -42,11 +42,12 @@ class _AssignCentersIndexer:
     # is set when the source carries an alpha/mask band and --mask is on.
     src: rio.DatasetReader | None = None
     apply_mask: bool = False
+    # Lock guarding reads of ``src``; share the one rioxarray uses for ``da``
+    # (the same GDAL dataset), which is not safe for concurrent access.
+    read_lock: Any = None
 
     def __post_init__(self):
-        # ``src`` is one GDAL dataset shared by every worker thread and is not
-        # safe for concurrent access.
-        self._read_lock = threading.Lock()
+        self._read_lock = self.read_lock or threading.Lock()
 
     def process_window(self, window):
         """Index all pixels in this raster window to their containing DGGS cell."""

--- a/raster2dggs/transfers/assign_centers.py
+++ b/raster2dggs/transfers/assign_centers.py
@@ -8,13 +8,16 @@ method callable by ThreadPoolExecutor.map.
 from __future__ import annotations
 
 import dataclasses
+import threading
 from collections.abc import Callable
 from typing import Any
 
 import pyproj
+import rasterio as rio
 import xarray as xr
 
 from raster2dggs.interfaces import IRasterIndexer
+from raster2dggs.profiling import PROFILER
 
 
 @dataclasses.dataclass(repr=False)
@@ -35,10 +38,28 @@ class _AssignCentersIndexer:
     emit_nodata_value: Any | None
     transformer: pyproj.Transformer
     write_result: Callable
+    # The dataset behind ``da``, needed only to read its mask bands. apply_mask
+    # is set when the source carries an alpha/mask band and --mask is on.
+    src: rio.DatasetReader | None = None
+    apply_mask: bool = False
+
+    def __post_init__(self):
+        # ``src`` is one GDAL dataset shared by every worker thread and is not
+        # safe for concurrent access.
+        self._read_lock = threading.Lock()
 
     def process_window(self, window):
         """Index all pixels in this raster window to their containing DGGS cell."""
         sdf = self.da.rio.isel_window(window)
+        valid_mask = None
+        if self.apply_mask:
+            with PROFILER.phase("stage1.read_mask"), self._read_lock:
+                valid_mask = (
+                    self.src.read_masks(
+                        indexes=list(self.selected_indices), window=window
+                    )
+                    != 0
+                )
         result = self.indexer.index_func(
             sdf,
             self.resolution,
@@ -49,5 +70,6 @@ class _AssignCentersIndexer:
             emit_nodata_value=self.emit_nodata_value,
             transformer=self.transformer,
             selected_indices=self.selected_indices,
+            valid_mask=valid_mask,
         )
         self.write_result(result, window)

--- a/raster2dggs/transfers/assign_centers.py
+++ b/raster2dggs/transfers/assign_centers.py
@@ -53,13 +53,12 @@ class _AssignCentersIndexer:
         sdf = self.da.rio.isel_window(window)
         valid_mask = None
         if self.apply_mask:
+            # Read in the DataArray's own band order, not selected_indices
+            # order: when every band is selected the DataArray is left in
+            # natural order regardless of the order -b was given in.
+            band_order = [int(b) for b in sdf["band"].values]
             with PROFILER.phase("stage1.read_mask"), self._read_lock:
-                valid_mask = (
-                    self.src.read_masks(
-                        indexes=list(self.selected_indices), window=window
-                    )
-                    != 0
-                )
+                valid_mask = self.src.read_masks(indexes=band_order, window=window) != 0
         result = self.indexer.index_func(
             sdf,
             self.resolution,

--- a/raster2dggs/transfers/interpolation.py
+++ b/raster2dggs/transfers/interpolation.py
@@ -98,6 +98,9 @@ class _SampleIndexer:
     # keeps all non-default fields before these.
     bicubic_a: float = dataclasses.field(default=-0.5)
     lanczos_lobes: int = dataclasses.field(default=3)
+    # Set when the source carries an alpha/mask band and --mask is on: masked
+    # pixels are read as NaN so every kernel treats them as nodata.
+    apply_mask: bool = dataclasses.field(default=False)
 
     def __post_init__(self):
         self._read_lock = threading.Lock()
@@ -159,8 +162,18 @@ class _SampleIndexer:
         Reads are serialised: ``src`` is one GDAL dataset shared by every worker
         thread, and GDAL datasets are not safe for concurrent access.
         """
+        indexes = list(self.selected_indices)
         with PROFILER.phase("stage1.read_block"), self._read_lock:
-            return self.src.read(indexes=list(self.selected_indices), window=window)
+            data = self.src.read(indexes=indexes, window=window)
+            if not self.apply_mask:
+                return data
+            masks = self.src.read_masks(indexes=indexes, window=window)
+        # Masked pixels become NaN here, upstream of every kernel: each one
+        # already keys its nodata handling off isnan. Integer bands are widened
+        # so they can hold NaN.
+        data = data.astype(float, copy=False)
+        data[masks == 0] = np.nan
+        return data
 
     def _expand_window(self, window, margin: int):
         """Expand window by margin pixels, clamped to raster bounds."""

--- a/raster2dggs/transfers/interpolation.py
+++ b/raster2dggs/transfers/interpolation.py
@@ -5,7 +5,7 @@ _SampleIndexer holds all shared state (open raster, transformer, indexer
 config) and exposes process_nn / process_bilinear / process_bicubic /
 process_lanczos as bound methods.  Each method accepts only a rasterio
 Window and returns None, making them drop-in callables for
-ThreadPoolExecutor.map.
+the Stage 1 worker, once per window.
 
 Keeping the sampling logic here (rather than as closures inside
 initial_index) makes the methods independently unit-testable and keeps
@@ -79,7 +79,7 @@ class _SampleIndexer:
     """Shared context for all --transfer sample process methods.
 
     Instantiate once per raster open; pass bound methods (e.g.
-    ctx.process_bicubic) to ThreadPoolExecutor.map.
+    ctx.process_bicubic) to the Stage 1 worker, once per window.
     """
 
     src: rio.DatasetReader
@@ -101,9 +101,12 @@ class _SampleIndexer:
     # Set when the source carries an alpha/mask band and --mask is on: masked
     # pixels are read as NaN so every kernel treats them as nodata.
     apply_mask: bool = dataclasses.field(default=False)
+    # Lock guarding reads of ``src``; share the one rioxarray uses for ``da``
+    # (the same GDAL dataset), which is not safe for concurrent access.
+    read_lock: Any = dataclasses.field(default=None)
 
     def __post_init__(self):
-        self._read_lock = threading.Lock()
+        self._read_lock = self.read_lock or threading.Lock()
         lobe = self.lanczos_lobes
         self._lanczos_ns: int = 2 * lobe
         self._lanczos_offsets_int: np.ndarray = np.arange(

--- a/raster2dggs/transfers/overlay.py
+++ b/raster2dggs/transfers/overlay.py
@@ -2,7 +2,7 @@
 Raster overlay context for --transfer overlay_weighted, overlay_mode, mass_preserve.
 
 _OverlayIndexer holds all shared state (raster path, indexer config) and exposes
-process_window as a bound method callable by ThreadPoolExecutor.map.
+process_window, called once per raster window in a Stage 1 worker process.
 
 exactextract reads from the full raster path for every polygon batch, so a cell
 whose polygon spans multiple raster windows always receives correct combined stats.
@@ -144,25 +144,56 @@ class _MaskedRasterSource(RasterioRasterSource):
         arr = super().read_window(x0, y0, nx, ny)
         if not np.ma.isMaskedArray(arr):
             return arr
-        # float64 is exact for every integer type GDAL produces.
-        return np.ma.filled(arr.astype(np.float64), np.nan)
+        # The narrowest float that holds every value of the source dtype
+        # exactly: float32 has a 24-bit significand, so it is exact for 8- and
+        # 16-bit integers (and float32 itself); wider integers need float64.
+        dtype = (
+            np.float32
+            if arr.dtype.itemsize <= 2 or arr.dtype == np.float32
+            else np.float64
+        )
+        return np.ma.filled(arr.astype(dtype), np.nan)
+
+
+class _RawRasterSource(RasterioRasterSource):
+    """exactextract raster source that ignores the GDAL dataset mask (--no-mask):
+    pixel values are read as stored, and only the declared nodata value (via
+    the inherited nodata_value) marks a pixel invalid."""
+
+    def read_window(self, x0, y0, nx, ny):
+        from rasterio.windows import Window
+
+        arr = self.ds.read(self.band_idx, window=Window(x0, y0, nx, ny), masked=False)
+        if self.scaled:
+            if issubclass(arr.dtype.type, np.integer):
+                arr = arr.astype(np.float64)
+            arr = arr * self.scale + self.offset
+        return arr
+
+
+def _band_name(ds: rio.DatasetReader, i: int) -> str | None:
+    # Named the way exactextract names bands read from a path (``band_{i}``,
+    # or unnamed for a single-band raster) so column renaming is unchanged.
+    return f"band_{i}" if ds.count > 1 else None
 
 
 def masked_raster_sources(ds: rio.DatasetReader, indices) -> list:
-    """Per-band exactextract sources for ``indices`` (1-based), named the way
-    exactextract names bands read from a path (``band_{i}``, or unnamed for a
-    single-band raster) so downstream column renaming is unchanged."""
-    return [
-        _MaskedRasterSource(ds, i, name=f"band_{i}" if ds.count > 1 else None)
-        for i in indices
-    ]
+    """Per-band exactextract sources for ``indices`` (1-based) that honour the
+    dataset mask (masked pixels read as NaN)."""
+    return [_MaskedRasterSource(ds, i, name=_band_name(ds, i)) for i in indices]
+
+
+def raw_raster_sources(ds: rio.DatasetReader, indices) -> list:
+    """Per-band exactextract sources for ``indices`` (1-based) that ignore the
+    dataset mask (raw pixel values; declared nodata only)."""
+    return [_RawRasterSource(ds, i, name=_band_name(ds, i)) for i in indices]
 
 
 @dataclasses.dataclass(repr=False)
 class _OverlayIndexer:
     """Shared context for --transfer overlay_weighted / overlay_mode / mass_preserve.
 
-    Instantiate once; pass ctx.process_window to ThreadPoolExecutor.map.
+    Instantiate once per worker process; call ctx.process_window per window.
     """
 
     raster_input: str
@@ -188,9 +219,8 @@ class _OverlayIndexer:
     shared_coverage_mask_path: str | None = None
     # Whether GDAL dataset masks (alpha / mask bands) count as nodata. When the
     # source has one, raster_source replaces raster_input as what exactextract
-    # reads: masked_raster_sources(...) with --mask, or a rioxarray DataArray
-    # opened with masked=False (raw pixel values) with --no-mask. None means
-    # "use raster_input".
+    # reads: masked_raster_sources(...) with --mask, raw_raster_sources(...)
+    # with --no-mask. None means "use raster_input".
     use_mask: bool = True
     raster_source: Any = None
 

--- a/raster2dggs/transfers/overlay.py
+++ b/raster2dggs/transfers/overlay.py
@@ -29,6 +29,7 @@ import pyarrow as pa
 import pyproj
 import rasterio as rio
 from exactextract import exact_extract
+from exactextract.raster import RasterioRasterSource
 from rasterio.warp import transform as warp_transform
 from rasterio.warp import transform_bounds
 from shapely.geometry import Polygon, shape
@@ -123,6 +124,40 @@ def _fix_antimeridian(poly):
     return shape(fixed)
 
 
+class _MaskedRasterSource(RasterioRasterSource):
+    """exactextract raster source that honours the GDAL dataset mask.
+
+    exactextract's own sources return numpy masked arrays for masked pixels,
+    but exactextract 0.3 ignores the mask for some partially-masked windows
+    (observed: a 7x7 uint8 window with 42 masked pixels read as fully valid,
+    while fully-masked and other partially-masked windows were fine). NaN in
+    a float array is handled reliably, so masked pixels -- declared nodata and
+    alpha/mask bands alike, via rasterio's masked read -- become NaN here.
+    """
+
+    def nodata_value(self):
+        # Nodata pixels are already NaN; declaring the value as well would
+        # compare an integer against a float array.
+        return None
+
+    def read_window(self, x0, y0, nx, ny):
+        arr = super().read_window(x0, y0, nx, ny)
+        if not np.ma.isMaskedArray(arr):
+            return arr
+        # float64 is exact for every integer type GDAL produces.
+        return np.ma.filled(arr.astype(np.float64), np.nan)
+
+
+def masked_raster_sources(ds: rio.DatasetReader, indices) -> list:
+    """Per-band exactextract sources for ``indices`` (1-based), named the way
+    exactextract names bands read from a path (``band_{i}``, or unnamed for a
+    single-band raster) so downstream column renaming is unchanged."""
+    return [
+        _MaskedRasterSource(ds, i, name=f"band_{i}" if ds.count > 1 else None)
+        for i in indices
+    ]
+
+
 @dataclasses.dataclass(repr=False)
 class _OverlayIndexer:
     """Shared context for --transfer overlay_weighted / overlay_mode / mass_preserve.
@@ -151,6 +186,13 @@ class _OverlayIndexer:
     # here.
     shared_weights_path: str | None = None
     shared_coverage_mask_path: str | None = None
+    # Whether GDAL dataset masks (alpha / mask bands) count as nodata. When the
+    # source has one, raster_source replaces raster_input as what exactextract
+    # reads: masked_raster_sources(...) with --mask, or a rioxarray DataArray
+    # opened with masked=False (raw pixel values) with --no-mask. None means
+    # "use raster_input".
+    use_mask: bool = True
+    raster_source: Any = None
 
     def __post_init__(self):
         # mass_preserve (sum) must not filter by coverage — partial sums are correct
@@ -281,7 +323,6 @@ class _OverlayIndexer:
                 if self.shared_coverage_mask_path is not None:
                     self._coverage_mask_path = self.shared_coverage_mask_path
                 else:
-                    data = src.read(masked=True)
                     mask_profile = src.profile.copy()
                     mask_profile.update(dtype="float32", nodata=None)
                     with tempfile.NamedTemporaryFile(
@@ -289,13 +330,24 @@ class _OverlayIndexer:
                     ) as tmp:
                         self._coverage_mask_path = tmp.name
                     self._own_temp_paths.append(self._coverage_mask_path)
-                    # data.mask is scalar False when the source has no nodata value;
-                    # broadcast to full (bands, height, width) shape before writing.
-                    validity = (~np.broadcast_to(data.mask, data.shape)).astype(
-                        np.float32
-                    )
+                    if self.use_mask:
+                        # A masked read honours declared nodata and any alpha /
+                        # mask band. data.mask is scalar False when nothing is
+                        # masked; broadcast to (bands, height, width).
+                        data = src.read(masked=True)
+                        validity = ~np.broadcast_to(data.mask, data.shape)
+                    else:
+                        # --no-mask: only the declared nodata value counts.
+                        data = src.read()
+                        validity = np.ones(data.shape, dtype=bool)
+                        for b, nd in enumerate(src.nodatavals):
+                            if nd is None:
+                                continue
+                            validity[b] = ~(
+                                np.isnan(data[b]) if np.isnan(nd) else data[b] == nd
+                            )
                     with rio.open(self._coverage_mask_path, "w", **mask_profile) as dst:
-                        dst.write(validity)
+                        dst.write(validity.astype(np.float32))
             else:
                 self._raster_footprint_wgs84 = None
                 self._coverage_mask_path = None
@@ -454,10 +506,13 @@ class _OverlayIndexer:
             main_ops = [weighted_agg]
         else:
             main_ops = [str(self.op)]
+        rast = (
+            self.raster_source if self.raster_source is not None else self.raster_input
+        )
         with PROFILER.phase("stage1.exactextract"):
             if is_geodesic:
                 result_df = exact_extract(
-                    self.raster_input,
+                    rast,
                     gdf,
                     main_ops,
                     weights=self._geodesic_weights_path,
@@ -466,7 +521,7 @@ class _OverlayIndexer:
                 )
             else:
                 result_df = exact_extract(
-                    self.raster_input,
+                    rast,
                     gdf,
                     main_ops,
                     include_cols="_fid",

--- a/tests/classes/helpers.py
+++ b/tests/classes/helpers.py
@@ -54,3 +54,75 @@ def make_gradient_raster(
         transform=from_bounds(*bounds, size, size),
     ) as dst:
         dst.write(data)
+
+
+def make_rgba_raster(
+    path: str,
+    bounds: tuple,
+    size: int,
+    pixel_value: int = 100,
+    masked_cols: int | None = None,
+) -> None:
+    """Write a uint8 RGBA WGS84 GeoTIFF with no nodata value, coverage expressed
+    solely by the alpha band -- the LINZ-mosaic pattern of issue #105.
+
+    The leftmost ``masked_cols`` columns (default: half the width) have alpha 0
+    and RGB (0, 0, 0); everywhere else alpha is 255 and RGB is ``pixel_value``.
+    """
+    from rasterio.enums import ColorInterp
+
+    if masked_cols is None:
+        masked_cols = size // 2
+    data = np.full((4, size, size), pixel_value, dtype=np.uint8)
+    data[3] = 255
+    data[:, :, :masked_cols] = 0
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=4,
+        dtype="uint8",
+        crs=CRS.from_epsg(4326),
+        transform=from_bounds(*bounds, size, size),
+    ) as dst:
+        dst.write(data)
+        dst.colorinterp = (
+            ColorInterp.red,
+            ColorInterp.green,
+            ColorInterp.blue,
+            ColorInterp.alpha,
+        )
+
+
+def make_internal_mask_raster(
+    path: str,
+    bounds: tuple,
+    size: int,
+    pixel_value: float = 1.0,
+    masked_cols: int | None = None,
+) -> None:
+    """Write a single-band float32 WGS84 GeoTIFF with no nodata value whose
+    validity is carried by an internal (TIFF) mask band: the leftmost
+    ``masked_cols`` columns (default: half) are masked, and hold 0.0."""
+    if masked_cols is None:
+        masked_cols = size // 2
+    data = np.full((1, size, size), pixel_value, dtype=np.float32)
+    data[:, :, :masked_cols] = 0.0
+    mask = np.full((size, size), 255, dtype=np.uint8)
+    mask[:, :masked_cols] = 0
+    with rasterio.Env(GDAL_TIFF_INTERNAL_MASK=True):
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=size,
+            width=size,
+            count=1,
+            dtype="float32",
+            crs=CRS.from_epsg(4326),
+            transform=from_bounds(*bounds, size, size),
+        ) as dst:
+            dst.write(data)
+            dst.write_mask(mask)

--- a/tests/classes/test_dataset_mask.py
+++ b/tests/classes/test_dataset_mask.py
@@ -1,0 +1,154 @@
+"""
+GDAL dataset masks (alpha bands, internal mask bands) honoured as nodata -- #105.
+
+Fixture rasters are 20x20 with the left half masked (alpha 0 / mask 0, pixel
+value 0) and the right half valid with a constant value. Any cell whose value
+differs from that constant has had masked pixels averaged in, so "every value
+equals the constant" is the whole assertion for the masked runs, while the
+--no-mask runs must show the black filler leaking through.
+"""
+
+import numpy as np
+import rasterio
+from classes.base import TestRunthrough, read_output
+from classes.helpers import make_internal_mask_raster, make_raster, make_rgba_raster
+from data.datapaths import TEST_OUTPUT_PATH
+
+from raster2dggs import common
+
+_BOUNDS = (174.0, -41.1, 174.1, -41.0)
+_SIZE = 20
+_VALUE = 100
+# H3 res 7 cells (~5 km²) hold ~16 of these 0.005° pixels, so cells straddle
+# the mask edge; res 9 cells hold about one pixel, exercising --sample.
+_RES = 7
+_SAMPLE_RES = 9
+
+
+def _rgba(path):
+    make_rgba_raster(path, _BOUNDS, _SIZE, pixel_value=_VALUE)
+
+
+def _internal_mask(path):
+    make_internal_mask_raster(path, _BOUNDS, _SIZE, pixel_value=1.0)
+
+
+class TestNeedsMaskRead(TestRunthrough):
+    def _check(self, make_func, expected):
+        path = self.make_temp_raster(make_func)
+        with rasterio.open(path) as src:
+            self.assertEqual(
+                common._needs_mask_read(src, range(1, src.count + 1)), expected
+            )
+
+    def test_alpha_band_needs_mask(self):
+        self._check(_rgba, True)
+
+    def test_internal_mask_needs_mask(self):
+        self._check(_internal_mask, True)
+
+    def test_declared_nodata_only_does_not(self):
+        self._check(lambda p: make_raster(p, _BOUNDS, _SIZE, nodata=-9999.0), False)
+
+    def test_all_valid_does_not(self):
+        self._check(lambda p: make_raster(p, _BOUNDS, _SIZE), False)
+
+
+class TestAlphaMask(TestRunthrough):
+    def setUp(self):
+        super().setUp()
+        self._raster = self.make_temp_raster(_rgba)
+
+    def _run(self, *extra_args, res=_RES):
+        self.invoke_cli("h3", self._raster, TEST_OUTPUT_PATH, res, *extra_args)
+        return read_output(TEST_OUTPUT_PATH).to_pandas()
+
+    def _assert_only_valid_values(self, df, bands=("band_1", "band_2", "band_3")):
+        self.assertGreater(len(df), 0)
+        for b in bands:
+            vals = df[b].to_numpy(dtype=float)
+            self.assertTrue(
+                np.all(vals == _VALUE), f"{b}: masked pixels leaked in: {vals}"
+            )
+
+    # --point (default)
+    def test_point_masks_pixels_and_consumes_alpha(self):
+        df = self._run()
+        self.assertNotIn("band_4", df.columns)
+        self._assert_only_valid_values(df)
+
+    def test_point_no_mask_emits_alpha_and_filler(self):
+        df = self._run("--no-mask")
+        self.assertIn("band_4", df.columns)
+        self.assertLess(df["band_1"].min(), _VALUE)  # black filler averaged in
+        self.assertLess(df["band_4"].min(), 255)
+
+    def test_point_explicit_alpha_band_is_emitted_as_data(self):
+        # Selected explicitly, the alpha band is data and is always valid, so
+        # under 'omit' a masked pixel still yields a row: NaN in the masked
+        # bands, alpha 0 -- i.e. a per-cell coverage feature.
+        df = self._run("-b", "1", "-b", "4")
+        self.assertIn("band_4", df.columns)
+        b1 = df["band_1"].to_numpy(dtype=float)
+        b4 = df["band_4"].to_numpy(dtype=float)
+        self.assertTrue(np.all(b1[~np.isnan(b1)] == _VALUE))
+        self.assertTrue(np.isnan(b1).any())  # fully masked cells survive via alpha
+        self.assertTrue(np.all(b4[np.isnan(b1)] == 0))
+        self.assertTrue(np.all(b1[b4 == 255] == _VALUE))
+
+    def test_point_emit_writes_fill_for_masked(self):
+        df = self._run("-n", "emit", "--nodata-fill", "-1", "-d", "0")
+        vals = df["band_1"].to_numpy(dtype=float)
+        self.assertTrue((vals == -1).any())  # fully masked cells
+        self.assertTrue((vals == _VALUE).any())  # fully valid cells
+
+    def test_point_masked_run_has_fewer_cells(self):
+        n_masked = len(self._run())
+        n_raw = len(self._run("--no-mask"))
+        self.assertLess(n_masked, n_raw)
+
+    # --sample
+    def test_sample_nn_masks(self):
+        df = self._run("--sample", "nn", res=_SAMPLE_RES)
+        self._assert_only_valid_values(df)
+
+    def test_sample_bilinear_masks(self):
+        df = self._run("--sample", "bilinear", res=_SAMPLE_RES)
+        self._assert_only_valid_values(df)
+
+    def test_sample_no_mask_leaks_filler(self):
+        df = self._run("--sample", "nn", "--no-mask", res=_SAMPLE_RES)
+        self.assertLess(df["band_1"].min(), _VALUE)
+
+    # --overlay
+    def test_overlay_weighted_masks(self):
+        df = self._run("--overlay", "weighted")
+        self._assert_only_valid_values(df)
+
+    def test_overlay_no_mask_leaks_filler(self):
+        df = self._run("--overlay", "weighted", "--no-mask")
+        self.assertLess(df["band_1"].min(), _VALUE)
+
+    def test_overlay_coverage_threshold_counts_masked_as_invalid(self):
+        n_all = len(self._run("--overlay", "weighted"))
+        n_vct = len(self._run("--overlay", "weighted", "-vct", "0.9"))
+        self.assertLess(n_vct, n_all)  # edge cells straddling the mask are dropped
+
+
+class TestInternalMask(TestRunthrough):
+    def setUp(self):
+        super().setUp()
+        self._raster = self.make_temp_raster(_internal_mask)
+
+    def _run(self, *extra_args):
+        self.invoke_cli("h3", self._raster, TEST_OUTPUT_PATH, _RES, *extra_args)
+        return read_output(TEST_OUTPUT_PATH).to_pandas()
+
+    def test_point_masks_pixels(self):
+        df = self._run()
+        self.assertGreater(len(df), 0)
+        self.assertTrue(np.all(df["band_1"].to_numpy(dtype=float) == 1.0))
+
+    def test_point_no_mask_leaks_filler(self):
+        df = self._run("--no-mask")
+        self.assertLess(df["band_1"].min(), 1.0)

--- a/tests/classes/test_dataset_mask.py
+++ b/tests/classes/test_dataset_mask.py
@@ -102,6 +102,26 @@ class TestAlphaMask(TestRunthrough):
         self.assertTrue((vals == -1).any())  # fully masked cells
         self.assertTrue((vals == _VALUE).any())  # fully valid cells
 
+    def test_point_all_bands_reordered_keeps_masks_aligned(self):
+        # Every band selected, non-natural order: the DataArray stays in
+        # natural order, so masks must be read in that order too. Alpha's own
+        # mask is all-valid, so a misalignment would unmask band 1.
+        df = self._run("-b", "4", "-b", "1", "-b", "2", "-b", "3")
+        b1 = df["band_1"].to_numpy(dtype=float)
+        b4 = df["band_4"].to_numpy(dtype=float)
+        self.assertTrue(np.all(b1[~np.isnan(b1)] == _VALUE))
+        # alpha-as-data is averaged per cell, so anything in [0, 255] is fine
+        self.assertTrue(np.all((b4 >= 0) & (b4 <= 255)))
+        self.assertTrue((b4 == 0).any())  # fully masked cells survive via alpha
+
+    def test_point_emit_without_fill_writes_nan(self):
+        df = self._run("-n", "emit")
+        b1 = df["band_1"].to_numpy(dtype=float)
+        self.assertTrue(np.isnan(b1).any())
+        self.assertTrue(np.all(b1[~np.isnan(b1)] == _VALUE))
+        # emit keeps every cell, masked or not: same cell count as --no-mask.
+        self.assertEqual(len(df), len(self._run("--no-mask")))
+
     def test_point_masked_run_has_fewer_cells(self):
         n_masked = len(self._run())
         n_raw = len(self._run("--no-mask"))
@@ -114,6 +134,14 @@ class TestAlphaMask(TestRunthrough):
 
     def test_sample_bilinear_masks(self):
         df = self._run("--sample", "bilinear", res=_SAMPLE_RES)
+        self._assert_only_valid_values(df)
+
+    def test_sample_bicubic_masks(self):
+        df = self._run("--sample", "bicubic", res=_SAMPLE_RES)
+        self._assert_only_valid_values(df)
+
+    def test_sample_lanczos_masks(self):
+        df = self._run("--sample", "lanczos", res=_SAMPLE_RES)
         self._assert_only_valid_values(df)
 
     def test_sample_no_mask_leaks_filler(self):
@@ -133,6 +161,24 @@ class TestAlphaMask(TestRunthrough):
         n_all = len(self._run("--overlay", "weighted"))
         n_vct = len(self._run("--overlay", "weighted", "-vct", "0.9"))
         self.assertLess(n_vct, n_all)  # edge cells straddling the mask are dropped
+
+    def test_overlay_coverage_threshold_no_mask_counts_masked_as_valid(self):
+        # With --no-mask the coverage raster must not honour the alpha band
+        # either, so only cells at the raster's own edge fall below threshold.
+        n_masked = len(self._run("--overlay", "weighted", "-vct", "0.9"))
+        n_raw = len(self._run("--overlay", "weighted", "-vct", "0.9", "--no-mask"))
+        self.assertGreater(n_raw, n_masked)
+
+    def test_overlay_mode_masks(self):
+        df = self._run("--overlay", "mode")
+        self._assert_only_valid_values(df)
+
+    def test_overlay_explicit_alpha_band_is_emitted_as_data(self):
+        df = self._run("--overlay", "weighted", "-b", "1", "-b", "4")
+        self.assertIn("band_4", df.columns)
+        b1 = df["band_1"].to_numpy(dtype=float)
+        self.assertTrue(np.all(b1[~np.isnan(b1)] == _VALUE))
+        self.assertTrue(np.all(df["band_4"].to_numpy(dtype=float) <= 255))
 
 
 class TestInternalMask(TestRunthrough):


### PR DESCRIPTION
Fixes #105

## Problem

Rasters whose validity is carried by GDAL's dataset mask — an alpha band, or an internal/sidecar mask band — rather than a declared nodata value were read as fully valid. For the LINZ mosaics (uint8 RGBA, no nodata) that means (0, 0, 0) filler averaged into every cell along the coverage edge: means pulled toward 0, inflated std, and phantom all-black cells. Value-based nodata is no fix (0 is real imagery data).

## Change

New \`--mask/--no-mask\` (default **on**). Masked pixels are treated exactly like declared nodata everywhere the code branches on nodata: \`--nodata omit|emit\`, \`--nodata-fill\`, \`--agg\` statistics, \`--overlay\` weights and \`-vct\` accounting, \`--sample\` kernels.

- **point** (\`assign_centers\`): \`src.read_masks(...)\` per window, in the DataArray's band order, OR-ed into the existing nodata mask in \`index_func\` (new optional \`valid_mask\` parameter).
- **sample** (\`interpolation\`): masked pixels become NaN in \`_read_window\`, upstream of every kernel (each already keys off \`isnan\`; fast paths included).
- **overlay**: exactextract is handed per-band rasterio-backed sources instead of the path — \`_MaskedRasterSource\` (masked read → NaN in the narrowest exact float: float32 for ≤16-bit/float32 sources, float64 otherwise) with \`--mask\`, \`_RawRasterSource\` (values as stored, declared nodata only) with \`--no-mask\`. **The masked source is a workaround for an exactextract 0.3 bug**: it silently ignores numpy masked arrays for rasters with a non-zero origin (pure-NumPy repro: correct at origin (0,0), mask dropped entirely at (174, −41.1); \`grid_compat_tol\` has no effect; fully-masked windows unaffected). Its own GDAL/rasterio sources return masked arrays, so they cannot be relied on. NaN is handled correctly. The \`-vct\` coverage raster follows the same switch.
- **Band selection**: an alpha band not explicitly selected with \`-b\` is consumed as the mask and not emitted (RGBA → \`band_1..3\`); \`-b 4\` still emits it as data (a per-cell coverage feature; alpha is then always valid, so under \`omit\` fully masked pixels still yield rows with NaN in the other bands).
- The mask is only read when \`src.mask_flag_enums\` shows an alpha/per-dataset mask for a selected band (\`common._needs_mask_read\`), in every mode — declared-nodata-only rasters see no extra I/O and identical output.
- **Locking**: one lock per worker guards all reads of the shared GDAL dataset (rioxarray's and the mask reads).
- README: help dump updated; new "Nodata and dataset masks" section, including that \`--nodata-fill\` participates in aggregation and that \`GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR\` disables sidecar \`.msk\` discovery.

## Compatibility

Output **changes for existing users of alpha-masked rasters**: fewer rows (masked cells gone) and no alpha column unless selected with \`-b\`. \`--no-mask\` restores the previous behaviour. Declared-nodata-only rasters are unaffected. Suggest a minor version bump.

## Tests

\`tests/classes/test_dataset_mask.py\` (24 tests) with two new helpers (\`make_rgba_raster\`, \`make_internal_mask_raster\`): mask detection; point/sample (nn, bilinear, bicubic, lanczos)/overlay (weighted, mode) yield only valid values on a half-masked RGBA raster while \`--no-mask\` leaks the filler; alpha consumed vs. emitted with \`-b 4\` (point and overlay); all-bands-reordered mask alignment; \`-n emit\` with and without \`--nodata-fill\`; \`-vct\` counts masked pixels as invalid under \`--mask\` and valid under \`--no-mask\`; internal-mask raster. Full suite: **560 passed**, 16 skipped; black + ruff clean.

## Verification on the #105 sample (\`AS24_edge.tiff\`, 44.7 % alpha-masked)

Baseline command (\`h3 -r larger-than-pixel -n omit -b 1 -b 2 -b 3 -p 12 --point value -a mean,std,min -d 0 -co\`): before → 45,324 rows, **1,439** cells with mean 0, min 0; after → 43,885 rows, **0** cells with mean 0, min 9. \`s2 -r 17 --overlay weighted\`: masked → 3,170 rows, 0 black cells; \`--no-mask\` → 5,645 rows, 2,479 black cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)